### PR TITLE
Update _get-sdk-linux.md

### DIFF
--- a/src/docs/get-started/install/_get-sdk-linux.md
+++ b/src/docs/get-started/install/_get-sdk-linux.md
@@ -144,7 +144,11 @@ install Flutter using the following steps.
 
     For additional download options, see `flutter help precache`.
 
-    对于这些可选的下载项，请参考 `flutter help precache`。
+    对于这些可选的下载项，请参考 `flutter help precache`。如果执行命令后超过5分钟后还是停在`Building flutter tool...`不动，可以将其中断，设置镜像地址后再执行:
+    ```
+    $ export PUB_HOSTED_URL=https://pub.flutter-io.cn
+    $ export FLUTTER_STORAGE_BASE_URL=https://storage.flutter-io.cn
+    ```
 
 You are now ready to run Flutter commands!
 


### PR DESCRIPTION
`flutter precache` 需要下载资源, 对于内地用户直接就卡死在`Building flutter tool...`不动. 增加设置镜像的提示, 帮助解决默认库速度缓慢问题.

NOTE: We love contributions, but we hate spam. If your PR doesn't improve flutter.dev, we'll close it and label it as `invalid`.

Fixes #<issue number>.

Changes proposed in this pull request:

*  
* 
