### PR TITLE
Delete the english under the post/ articles

### DIFF
--- a/src/posts/Flutter-io19.md
+++ b/src/posts/Flutter-io19.md
@@ -1,167 +1,89 @@
 ---
-title: Flutter 1.5 发布
+title: Flutter 1.5 发布: 适用于移动、Web、嵌入式和桌面平台的便携式界面框架
+toc: true
 ---
-
-## Flutter: a Portable UI Framework for Mobile, Web, Embedded, and Desktop
-
-## Flutter 1.5 发布: 适用于移动、Web、嵌入式和桌面平台的便携式界面框架
 
 **作者: Flutter 团队**
 
-Today marks an important milestone for the [Flutter framework](https://flutter.dev/), as we expand our focus from mobile to incorporate a broader set of devices and form factors. At I/O, we’re releasing our first technical preview of [Flutter for web](https://flutter.dev/web), announcing that Flutter is powering Google’s smart display platform including the Google Home Hub, and delivering our first steps towards supporting desktop-class apps with Chrome OS.
-
 I/O 期间我们迎来 [Flutter 框架](https://flutter.dev/) 的一个重要里程碑，因为我们的开发重点从移动平台扩展到了更广泛的设备和机型。在 I/O 大会上，我们发布了 [Web 版 Flutter 的首个技术预览版](https://flutter.dev/web)，宣布 Flutter 将为包括 Google Home Hub 在内的 Google Smart Display 平台提供技术支持，并迈出利用 Chrome 操作系统支持桌面级应用的第一步。
-
-## From Mobile to Multi-Platform
 
 ## 从移动设备到多平台
 
-For a long time, the Flutter team mission has been to build the best framework for developing mobile apps for iOS and Android. We believe that mobile development is ripe for improvement, with developers today forced to choose between building the same app twice for two platforms, or making compromises to use cross-platform frameworks. Flutter hits the sweet spot of enabling a single codebase to deliver beautiful, fast, tailored experiences with high developer productivity for both platforms, and we’ve been excited to see how our early efforts have flourished into one of the [most popular open source projects](https://github.com/flutter/flutter).
-
 长期以来，Flutter 团队的使命一直是为开发 iOS 和 Android 版移动应用构建最佳框架。我们认为对移动开发作出改进的时机已经成熟，因为现在开发者不得不选择在两个平台上构建相同的应用两次，或者作出某些妥协以使用跨平台框架。Flutter 提供了一种最有效的方式，使单个代码库能够为两个平台提供美观、快速和量身定制的体验，并提高开发者的工作效率。我们很高兴能够看到早期的努力成功催生出目前最热门的[开源项目](https://github.com/flutter/flutter)之一。
-
-As we started to home in on [our 1.0 release last year](https://developers.googleblog.com/2018/12/flutter-10-googles-portable-ui-toolkit.html), we began experimenting with broadening the scope of Flutter to other platforms. This was triggered both by internal teams within Google who are increasingly relying on Flutter, as well as the latent potential of the [Dart platform](https://dart.dev) for delivering portable experiences. In particular, a small team who were already building a web framework for Dart for internal usage started an exploratory project (codename “Hummingbird”) to evaluate the technical merits of porting the Flutter engine to support the standards-based web.
 
 从去年开始着力开发 1.0 版本时，我们就开始尝试将 Flutter 的范围扩展到其他平台。这是基于两方面考虑: 一是 Google 内部团队越来越依赖于 Flutter，二是 [Dart 平台](https://dart.dev)有提供便捷式体验的潜力。特别是，已经着手为 Dart 构建 Web 框架以供内部使用的小型团队启动了一个探索性项目 (代号为 "Hummingbird")，以评估移植 Flutter 引擎以支持基于标准的 Web 有何技术优势。
 
-The results of this project were startling, thanks in large part to the rapid progress in web browsers like Chrome, Firefox, and Safari, which have pervasively delivered hardware-accelerated graphics, animation, and text as well as fast JavaScript execution. Within a few months of beginning the project, we had the core Flutter framework primitives working, and soon after we had demos running on mobile and desktop browsers. Along with Dart’s long pedigree of compiling for the web, this proved that we could also bring the Flutter framework and apps to run on the web.
-
 该项目的成效令人惊叹，这在很大程度上要归功于 Chrome、Firefox 和 Safari 等网络浏览器的快速发展。这些浏览器广泛地提供了硬件加速的图形、动画和文本，以及较快的 JavaScript 执行速度。在项目刚开始的几个月内，我们就成功构建了 Flutter 的核心框架原语。不久之后，我们在移动和桌面浏览器上运行了演示版本。长期以来，Dart 语言经常用于编译网页内容，这证明我们也能在 Web 端运行 Flutter 框架和应用。
 
-In parallel, the core Flutter project has been making progress to enable desktop-class apps, with input paradigms such as keyboard and mouse, window resizing, and tooling for Chrome OS app development. The exploratory work that we did for embedding Flutter into desktop-class apps running on Windows, Mac and Linux has also graduated into the core Flutter engine.
-
 与此同时，Flutter 核心项目不断取得进展，进而推动桌面级应用的发展，其中包括键盘和鼠标等输入工具、窗口大小调整，以及适用于 Chrome 操作系统应用开发的调试工具。针对在 Windows、Mac 和 Linux 上运行的桌面级应用，我们嵌入了 Flutter，而这项探索性工作已逐步演变成 Flutter 的核心引擎。
-
-## A Portable UI Framework for All Screens
 
 ## 适用于所有屏幕的便携式界面框架
 
 ![Flutter Mobile, Web, Desktop, and Embedded](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot5-release/flutter-platforms.png){:width="85%"}
 
-It’s worth pausing for a moment to acknowledge the business potential of a high-performance, portable UI framework that can deliver beautiful, tailored experiences to such a broad variety of form factors from a single codebase.
-
 毋庸置疑，高性能的便携式界面框架具有巨大的商业潜力。该框架可以通过单个代码库来为各种设备提供量身定制的出色体验。
-
-For startups, the ability to reach users on mobile, web, or desktop through the same app lets them reach their full audience from day one, rather than having limits due to technical considerations. Especially for larger organizations, the ability to deliver the same experience to all users with one codebase reduces complexity and development cost, and lets them focus on improving the quality of that experience.
 
 对于创业公司来说，这让他们能够通过同一个应用在移动端、Web 端或桌面端接触用户。如此一来，他们从一开始就能全面覆盖所有用户，而不会受到技术上的限制。对于大型组织来说尤其如此，因为他们能够使用同一个代码库为所有用户提供相同的体验，而这会降低工作复杂度和开发成本，更加专注于提升相关体验的质量。
 
-With support for mobile, desktop, and web apps, our mission expands: we want to build **the best framework for developing beautiful experiences for _any_ screen**.
-
 实现对移动、桌面和网络应用的支持后，我们肩负更大的使命: **我们要构建最佳框架，以便为所有屏幕开发出色体验。**
-
-## Flutter for Web
 
 ## 适用于 Web 平台的 Flutter
 
-This week, we are releasing the **first technical preview of Flutter for the web**. While this technology is still in development, we are ready for early adopters to try it out and give us feedback. Our initial vision for Flutter on the web is not as a general purpose replacement for the document experiences that HTML is optimized for; instead we intend it as a great way to build highly interactive, graphically rich content, where the benefits of a sophisticated UI framework are keenly felt.
-
 我们即将发布 Web 版 Flutter 的**首个技术预览版**。虽然这项技术还在开发中，但我们准备邀请尝鲜者来试用并提供反馈。对于 Web 版 Flutter，我们的最初设想并不是将其用作文档体验 (针对其优化 HTML ) 的通用替代品；相反，我们打算通过这种有效方式构建高度交互和图形丰富的内容，从而切实感受到成熟界面框架所带来的益处。
-
-To showcase Flutter for the web, we worked with the New York Times to build a demo. In addition to world-class news coverage, the New York Times is famous for its crossword and other puzzle games. Since avid puzzlers want to play on whatever device they’re using at the time, their development team was attracted to Flutter as a potential solution for their needs. Discovering that they could reach the web with the same code was a huge boon. At Google I/O this week, you can get a sneak peek of their [newly refreshed KENKEN puzzle game](https://www.nytimes.com/games/prototype/kenken), which runs with the same code on Android, iOS, web, Mac, and Chrome OS.
 
 为了展示 Web 版 Flutter，我们与《纽约时报》合作构建了一个演示版本。《纽约时报》不仅是世界一流的新闻媒体，而且以设计纵横字谜等益智游戏而闻名。由于狂热的解谜玩家希望能在当时使用的任何设备上玩游戏，所以《纽约时报》的开发团队把目光转向 Flutter，将其作为满足读者需求的潜在解决方案。发现能够利用同一组代码访问网页给他们带来了巨大裨益。在 Google I/O 大会上，您可以率先了解他们最近更新的 [KENKEN 解谜游戏](https://www.nytimes.com/games/prototype/kenken)。该游戏利用同一组代码在 Android、iOS、Web、Mac 和 Chrome 操作系统上运行。
 
 ![ken-gratulations puzzle](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot5-release/nyt-game.gif){:width="85%"}
 
-Here’s what Eric von Coelln, Executive Director of Puzzles at the New York Times has to say about their experiences with Flutter:
-
 以下是《纽约时报》解谜游戏执行总监 Eric von Coelln 对 Flutter 使用体验的看法:
 
-> _"The New York Times Crossword has more than 400,000 stand-alone subscriptions and is a daily ritual for puzzle solvers. Along with the Crossword, we’ve grown our portfolio of digital puzzles that reaches more than two million solvers each month._
-> 
 > “《纽约时报》纵横字谜游戏的单独订阅数量已超过 40 万份，玩这款游戏已经成为解谜者每天必做的事情。除了纵横字谜游戏，我们还开发了数字解谜游戏，每个月都吸引了超过 200 万名解谜者。 
-
-> _We were already beginning to explore Flutter as a potential solution to the challenge of quickly developing engaging, high-quality mobile experiences. Now the addition of being able to publish to web makes Flutter an even more appealing option to quickly deploy across all of our user platforms. This update of our old Flash-based KenKen game into a multi-platform playable experience is something we’re excited to bring to our solvers this year.”_
-> 
 > 我们已经开始探索 Flutter，并将其作为快速开发有趣和优质的移动体验这一挑战的潜在解决方案。现在，我们能够在 Web 端发布游戏，这使 Flutter 成为在所有用户平台快速部署内容的更具吸引力的选择。之前基于 Flash 的 KenKen 游戏经过更新，能够提供多平台的畅玩体验。今年我们很高兴能为解谜者带来全新体验。"
-
-There’s lots more to say about Flutter for web than we have space for here, so check out the dedicated [article about Flutter for web](https://medium.com/flutter-io/bringing-flutter-to-the-web-904de05f0df0) on the Flutter blog.
 
 由于篇幅有限，我们无法在此一一详述 Web 版 Flutter。若有兴趣，请前往 [Flutter 博客](https://medium.com/flutter-io/bringing-flutter-to-the-web-904de05f0df0)，阅读专门介绍 Web 版 Flutter 的文章。
 
-At this early stage, we’re eager to get your feedback on how you’d like to use Flutter for web. We expect to rapidly evolve the code, with a particular focus on performance, and harmonizing the codebase with the rest of the Flutter project.
-
 鉴于目前处于早期开发阶段，我们非常希望收到您的反馈，了解您希望如何使用 Web 版 Flutter。我们希望以性能为重中之重，快速开发代码，并与 Flutter 项目的其他部分协调代码库。
-
-## Flutter for Mobile Devices
 
 ## 适用于移动设备的 Flutter
 
-The core Flutter framework also receives an upgrade this week, with the **immediate availability of Flutter 1.5** in our stable channel. [Flutter 1.5](https://medium.com/flutter-io/announcing-flutter-1-5-6e5d7e35b75f) includes hundreds of changes in response to developer feedback, including updates for new App Store iOS SDK requirements, updates to the iOS and Material widgets, engine support for new device types, and Dart 2.3 featuring new [UI-as-code](https://medium.com/dartlang/making-dart-a-better-language-for-ui-f1ccaf9f546c) language features.
-
 我们还会升级核心 Flutter 框架，并会在**稳定版 channel 立即提供 Flutter 1.5**。根据开发者的反馈，我们对 [Flutter 1.5](https://medium.com/flutter-io/announcing-flutter-1-5-6e5d7e35b75f) 进行了数百处更改，包括对全新应用商店 iOS SDK 要求、iOS 和材料微件的更新，新增对新设备类型的引擎支持，以及对具有最新 [UI-as-code](https://medium.com/dartlang/making-dart-a-better-language-for-ui-f1ccaf9f546c) 语言特征的 Dart 2.3 作出改进。 
 
-As the framework itself matures, we’re investing in building out the supporting ecosystem. The architectural model of Flutter has always prioritized a small core framework, supplemented by a rich package community. In the last few months, Google has contributed production-quality packages for web views, Google Maps, and Firebase ML Vision, and this week, we’re adding [initial support for in-app payments](https://pub.flutter-io.cn/packages/in_app_purchase). And with over 2,000 open source packages available for Flutter, there are options available for most scenarios.
-
 随着框架本身逐渐成熟，我们正在设法构建支持生态系统。Flutter 的架构模型一贯优先考虑小型核心框架，并辅以丰富的软件包社区。在过去的几个月，Google 为网页视图、Google 地图和 Firebase ML Vision 提供了产品级质量的软件包。我们还将新增对 [应用内支付](https://pub.flutter-io.cn/packages/in_app_purchase) 的初步支持。得益于 2,000 多个适用于 Flutter 的开放源代码软件包，大多数场景均有合适的选择。 
-
-One particularly exciting project that we’re announcing this week at I/O is the [ML Kit Custom Image Classifier](http://github.com/firebase/mlkit-custom-image-classifier). Built using Flutter and Firebase, it offers an easy-to-use app-based workflow for creating custom image classification models. You can collect training data using the phone's camera, invite others to contribute to your datasets, trigger model training, and use trained models, all from the same app.
 
 在今年的 I/O 上，我们宣布推出一个尤其令人振奋的项目，即 [ML Kit 自定义图像分类器](http://github.com/firebase/mlkit-custom-image-classifier)。该工具利用 Flutter 和 Firebase 构建，可为创建自定义图像分类模型提供基于应用的简易工作流。您可以使用手机的摄像头收集训练数据、邀请他人为您的数据集贡献素材、触发模型训练以及使用训练过的模型，这些操作都可以在同一个应用中实现。
 
 ![Flutter ML Kit: create datasets, collaborate to collect data, train model, run inference](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot5-release/flutter-mlkit.png){:width="85%"}
 
-Flutter continues to grow in popularity and adoption. A [growing roster of demanding customers](https://flutter.dev/showcase) including eBay, Sonos, Square, Capital One, Alibaba and Tencent are developing apps with Flutter. And they’re having fun! Here’s what Larry McKenzie, a senior developer at eBay had to say about Flutter:
-
 Flutter 越来越受欢迎，使用人数也越来越多。[有需求的客户](https://flutter.dev/showcase)不断增加，其中包括 eBay、Sonos、Square、Capital One、Alibaba 和 Tencent。这些公司正在利用 Flutter 开发应用，并从中发现乐趣！以下是 eBay 的高级开发者 Larry McKenzie 对 Flutter 的看法:
 
-> _“Flutter is fast! Features that once took us multiple days to implement can be finished in a single day. Many problems we used to spend a lot of time on, simply no longer occur. Our team can now focus on creating more polished user experiences and delivering functionality. Flutter is enabling us to exceed expectations!”_
->
 > **“Flutter 运行速度很快！过去需要很多天才能实现的功能，现在只需一天就能完成。过去我们花费很多时间处理的问题，如今再也不会发生了。我们的团队现在可以专注于创建更出色的用户体验和提供相关功能。Flutter 让我们能够超越期望！”**
-
-More broadly, [LinkedIn recently conducted a study](https://learning.linkedin.com/blog/tech-tips/the-fastest-growing-skills-among-software-engineers--and-how-to-) that showed **Flutter is the single fastest-growing skill among software engineers**, based on site members claiming it on their profile over the last 12 months. And in the recent 2019 StackOverflow developer survey, [Flutter was listed as one of the most-loved developer frameworks](https://insights.stackoverflow.com/survey/2019#technology-_-most-loved-dreaded-and-wanted-other-frameworks-libraries-and-tools).
 
 从更广泛的角度上看，LinkedIn 最近进行的一项研究显示，根据网站成员在过去一年中所添加的个人资料，Flutter 是软件工程师中[增长最快的一项技能](https://learning.linkedin.com/blog/tech-tips/the-fastest-growing-skills-among-software-engineers--and-how-to-)。在最近的 2019 年 StackOverflow 开发者调查问卷中，Flutter 被列为 [最受欢迎的开发者框架之一](https://insights.stackoverflow.com/survey/2019#technology-_-most-loved-dreaded-and-wanted-other-frameworks-libraries-and-tools)。
 
-## Flutter for Desktop
-
 ## 适用于桌面平台的 Flutter
-
-Flutter is also being used on the desktop. For some months, we’ve been working on the desktop as [an experimental project](https://github.com/google/flutter-desktop-embedding). But now we’re graduating this into Flutter engine, integrating this work directly into the mainline repo. While these targets are not production-ready yet, we have published early [instructions for developing Flutter apps to run on Mac, Windows, and Linux](https://github.com/flutter/flutter/wiki/Desktop-shells).
 
 Flutter 目前也被用于桌面平台。在过去几个月，我们一直在研究桌面平台这一 [实验性项目](https://github.com/google/flutter-desktop-embedding)。但现在该项目逐渐演变成 Flutter 引擎，并将这项工作直接集成到 mainline repo 中。尽管这些目标尚未在生产环境中部署，但我们已发布早期说明，以便开发 [在 Mac、Windows 和 Linux 上运行的 Flutter 应用](https://github.com/flutter/flutter/wiki/Desktop-shells)。
 
-Another quickly growing Flutter platform is Chrome OS, with millions of Chromebooks being sold every year, particularly in education. Chrome OS is a perfect environment for Flutter, both for running Flutter apps, and as a developer platform, since it supports execution of both Android and Linux apps. With Chrome OS, you can use Visual Studio Code or Android Studio to develop a Flutter app that you can test and run locally on the same device without an emulator. You can also publish Flutter apps for Chrome OS to the Play Store, where millions of others can benefit from your creation.
-
 另一个快速发展的 Flutter 平台是 Chrome 操作系统，每年售出的 Chromebook 多达数百万台，尤其是在教育领域。无论是运行 Flutter 应用，还是作为开发者平台，Chrome 操作系统都为 Flutter 提供了绝佳环境，因为该系统支持执行 Android 和 Linux 应用。借助 Chrome 操作系统，您可以使用 Visual Studio Code 或 Android Studio 来开发 Flutter 应用，并在没有模拟器的情况下使用同一台设备本机测试和运行应用。您还可以在 Play Store 发布适用于 Chrome 操作系统的 Flutter 应用，让数百万用户因您的创作而受益。
-
-## Flutter for Embedded Devices
 
 ## 适用于嵌入式设备的 Flutter
 
-As the final example of Flutter’s portability, we offer Flutter embedded on other devices. We recently published [samples](https://medium.com/flutter-io/flutter-on-raspberry-pi-mostly-from-scratch-2824c5e7dcb1) that demonstrate Flutter running directly on smaller-scale devices like Raspberry Pi, and we offer an [embedding API for Flutter](https://github.com/flutter/flutter/wiki/Custom-Flutter-Engine-Embedders) that allows it to be used in scenarios including home, automotive and beyond.
-
 举例说明 Flutter 便携性的最后，我们将介绍可嵌入其他设备的 Flutter。最近我们发布了一些示例，演示了直接在 Raspberry Pi 等小型设备上运行 Flutter 的情况。我们还为 Flutter 开发了一个嵌入式 API，以便将其用于家庭和汽车等场景。
-
-Perhaps one of the most pervasive embedded platforms where Flutter is already running is on the smart display operating system that powers the likes of Google Home Hub.
 
 Smart Display 操作系统或许是 Flutter 目前已运行的最常见嵌入式平台之一，其为类似于 Google Home Hub 的设备提供技术支持。
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot5-release/flutter-google-home-hub.png){:width="85%"}
 
-Within Google, some Google-built features for the Smart Display platform are powered by Flutter today. And the Assistant team is excited to continue to expand the portfolio of features built with Flutter for the Smart Display in the coming months; the goal this year is to use Flutter to drive the overall system UI.
-
 目前在 Google 中，Smart Display 平台的部分 Google 自建功能由 Flutter 提供技术支持。Google 助理团队很高兴能够在接下来的几个月继续扩展通过 Flutter 为 Smart Display 构建的各项功能；而今年的目标是利用 Flutter 来驱动整个系统界面。
-
-## Other Resources
 
 ## 其他资源
 
-We often get asked by developers how they can get started with Flutter. We are pleased today to [announce a comprehensive new training course for Flutter](https://www.appbrewery.co/p/flutter-development-bootcamp-with-dart/), built by [The App Brewery](https://www.appbrewery.co/), authors of the highest-rated iOS training course on Udemy. Their new course has over thirty hours of content for Flutter, including videos, demos and labs, and with Google’s sponsorship, they are announcing today a time-limited discount of this course from the retail price of $199 to just $10.
-
 开发者经常询问我们如何完成 Flutter 入门。现在我们很高兴地宣布推出全新的综合性 Flutter 培训课程。该课程由 Udemy 上评分最高的 iOS 培训课程的制作者 The App Brewery 构建。他们的最新课程涵盖 30 多个小时的 Flutter 内容，其中包括视频、演示和实验。在 Google 的赞助下，The App Brewery 宣布推出此课程的限时折扣，原来的零售价为 199 美元，现只需 10 美元。
 
-Many developers are creating inspiring apps with Flutter. In the run-up to Google I/O, we ran a contest called Flutter Create to encourage developers to see what they could build with Flutter in 5KB or less of Dart code. We had over 750 unique entries from around the world, with some amazing examples that pushed what we imagine would be possible in such a small size.
-
 许多开发者正在利用 Flutter 开发振奋人心的应用。在 Google I/O 大会的筹备阶段，我们举办了名为 Flutter Create 的挑战赛，鼓励开发者使用不超过 5KB 的 Dart 代码通过 Flutter 构建内容。我们收到来自世界各地的 750 多个独特参赛作品，其中一些作品让我们大开眼界，谁能想到如此少的代码竟然能创造出如此精彩的作品。
-
-Today, we’re announcing the winners, which can be found on [flutter.dev/create](https://flutter.dev/create). Congratulations to the overall winner, Zebiao Hu, who wins a fully-loaded iMac Pro worth over $10,000!
 
 我们在此宣布获胜者，您可前往 flutter.dev/create 查看获胜名单。祝贺总冠军 Zebiao Hu，其将荣获价值超过 1 万美元的全加载式 iMac Pro！
 
 <iframe src="//player.bilibili.com/player.html?aid=52416421&page=1" scrolling="no" border="0" frameborder="no" framespacing="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
-
-Flutter is no longer a mobile framework, but a [multi-platform framework](https://youtu.be/5VbAwhBBHsg) that can help you reach your users wherever they are. We can’t wait to see what you’ll build with Flutter on the web, desktop, mobile, and beyond!
 
 Flutter 不再只是一个移动框架，更是一个多平台框架，可帮助您触及任何地方的用户。我们迫不及待地看到您利用 Flutter 在 Web、桌面、移动及其他平台上构建的内容！

--- a/src/posts/announcing-adobe-xd-support-for-flutter.md
+++ b/src/posts/announcing-adobe-xd-support-for-flutter.md
@@ -1,13 +1,9 @@
 ---
-title: Announcing Adobe XD support for Flutter
 title: 所见即所得 —— Adobe XD 的 Flutter 插件
 description: 我们很高兴宣布 CodePen 现已提供 Flutter 支持。
 ---
 
-Author: Tim Sneath, Product Manager for Flutter and Dart, Google
 文/ Tim Sneath, 谷歌 Flutter & Dart 产品经理
-
-Our goal with Flutter is to provide a rich canvas for creative expression. With native performance on iOS and Android, full control over every pixel rendered on the screen, and the ability to iterate rapidly with stateful hot reload, we want to unleash the potential of designers and developers to build beautiful experiences that aren’t limited by artificial technical boundaries.
 
 Flutter 希望成为任您挥洒创意的画布。
 凭借在 iOS 和 Android 上的原生性能体验、
@@ -16,15 +12,11 @@ Flutter 希望成为任您挥洒创意的画布。
 我们希望释放设计师和开发者的潜力，
 打造不受技术限制的精美体验。
 
-Last year at our [Flutter Interact event](https://www.youtube.com/watch?v=HjZxyTJzvYg&feature=emb_logo), we turned the spotlight on creators who are using Flutter to explore and experiment. We heard from digital artists like [Robert Felker](https://www.youtube.com/watch?v=DEppSs_ko48), who uses Flutter to build ethereal forms with generative algorithms. We presented [the work of creative agencies like gskinner](https://flutter.gskinner.com/), who created a series of innovative vignettes to demonstrate the potential of Flutter. And we saw a demonstration from Adobe of an [early prototype of a plugin for Adobe XD](https://www.youtube.com/watch?v=ukLBCRBlIkk&feature=youtu.be&t=3652) that exports Flutter code directly from their tool.
-
 在去年的 Flutter Interact 大会中，我们将焦点转向了那些使用 Flutter 进行探索和实验的创作者们。比如数字艺术家 Robert Felker，他使用 Flutter 通过生成算法 (generative algorithm) 构建了 [空灵的视觉效果和形式](https://v.youku.com/v_show/id_XNDQ2ODg0OTYxMg==.html)。我们还介绍了来自 [gskinner](https://flutter.gskinner.com/) 等创意机构的作品，他们用一件件充满创意的作品，展示了 Flutter 在表现形式方面的无限可能。另外，我们也了解到 Adobe 在 Flutter 方面的投入: 他们展示了一款 Adobe XD 插件的早期原型，让大家可以直接从 XD 中导出 Flutter 代码。
 
 ![generative-artwork](https://files.flutter-io.cn/posts/flutter-cn/2020/announcing-adobe-xd-support-for-flutter/generative-artwork.png){:width="90%"}
 
 △ Flutter 为创意提供了极富表现力的舞台，创造者可以尽情呈现优美、原生的体验，且不再受传统技术的束缚。(由 Flutter 绘制的生成艺术，Robert Felker 作品)
-
-Today, **we’re delighted to join Adobe in announcing that their XD to Flutter plugin is [now available as early access](https://adobe.com/go/xd_plugins_discover_plugin?pluginId=6eaf77ea)** for broader public testing. [Adobe XD](https://www.adobe.com/products/xd.html) is a UI/UX design and collaboration tool that helps teams create and share designs for websites, apps, voice interfaces, games, and more. Part of Adobe’s class-leading [Creative Cloud](https://www.adobe.com/creativecloud.html), XD allows designers to turn vector art, text, images, microinteractions, and animations into interactive prototypes that behave like working software products. The ability to export designs to Flutter further reduces the latency between creative ideas and product development, as an XD prototype can now become working Flutter code within minutes. Adobe XD supports design on Windows or macOS, and includes a [free starter plan](https://www.adobe.com/products/xd/compare-plans.html) to get you up and running.
 
 今天 **我们很高兴和 Adobe 共同宣布，Adobe XD Flutter 导出插件现在正式开放早期体验** ，欢迎大家踊跃参与测试。[Adobe XD](https://www.adobe.com/products/xd.html) 是一款 UI/UX 设计和协作工具，帮助团队创造和分享网站、应用、语音界面以及游戏等内容的设计方案。作为业界知名的 [Adobe Creative Cloud](https://www.adobe.com/creativecloud.html) 套件中的一员，XD 让创作者们可以将矢量绘图、文字、图像、小交互和动画资源共冶一炉，打造出可以交互的原型，来预览软件产品实际的运行效果。随着 Flutter 导出功能的加入，XD 原型现在可以在几分钟内转变成可用的 Flutter 代码，创意想法和产品开发的间隔被进一步缩短。Adobe XD 支持 Windows 和 macOS 系统，并且提供了[免费的入门计划](https://www.adobe.com/products/xd/compare-plans.html)，方便大家快速上手。
 
@@ -32,23 +24,13 @@ Today, **we’re delighted to join Adobe in announcing that their XD to Flutter 
 
 △ 使用插件即可轻松从 Adobe XD 导出到 Flutter
 
-## Exporting Flutter code from Adobe XD
-
 ## 从 Adobe XD 中导出 Flutter 代码
-
-Using the Flutter plugin in XD is straightforward. You can either export an individual drawing or component, or an artboard. Here’s how.
 
 在 XD 中使用 Flutter 插件很简单。您可以导出一个单独的绘图对象或组件，也可以导出整个画板 (artboard)。具体做法如下:
 
-Start by installing the [Flutter exporter plugin](https://adobe.com/go/xd_plugins_discover_plugin?pluginId=6eaf77ea). From Adobe XD, choose *Plugins > Discover Plugins*, and search for Flutter. Once you’ve installed it, you can display the UI Panel shown in the screenshot above by choosing *Plugins > Flutter > UI Panel*.
-
 首先，安装 Flutter 导出插件。在 Adobe XD 中，选择 *插件* > *发现插件* ( *Plugins* > *Discover Plugins* )，然后搜索 Flutter。安装完成后，选择 *插件* > *Flutter* > *UI 面板* ( *Plugins* > *Flutter* > *UI Panel* )，即可显示上图中的 UI 面板。
 
-Now add the [adobe_xd](https://pub.dev/packages/adobe_xd) package to your Flutter project by including it in your pubspec.yaml app manifest. This package provides helper functions to minimize boilerplate in the generated XD code.
-
 现在将 [adobe_xd package](https://pub.flutter-io.cn/packages/adobe_xd) 添加到您的 Flutter 项目中，只需将其包含在您的 pubspec.yaml 文件中即可。这个 package 提供了帮助函数，用来减少生成的 XD 代码中的样板代码。
-
-To export a single element, simply select the individual widget you’d like to export to Flutter, and choose the *Copy Selected *button from the UI panel. This copies the relevant Dart code to your clipboard, which you can use as the basis for a stateless or stateful widget:
 
 要导出单个元素，只需选择您想导出至 Flutter 的单个 widget，然后点击 UI 面板中的 *复制所选项* ( *Copy Selected* ) 按钮。这会将元素对应的 Dart 代码复制到您的剪贴板中，您可以基于这些代码打造有状态或无状态的 widget:
 
@@ -56,11 +38,7 @@ To export a single element, simply select the individual widget you’d like to 
 
 △ 导出的代码可以整合进现有的项目中，而且更新时不需要调整其他文件
 
-Another approach is to export the entire project. Assuming you’ve already got a Flutter app that you want to load the content into (including the adobe_xd package reference in pubspec.yaml), you can simply choose *Plugins > Flutter > Export All Widgets* from the UI panel, and set any additional configuration options you want.
-
 另一种方法是导出整个项目。假设您已经有了一个 Flutter 应用，并且您想把内容添加到这个应用里 (包括 pubspec.yaml 中对 adobe_xd package 的引用)，您只需从 UI 面板中选择 *插件* > *Flutter* > *导出全部 Widget* ( *Plugins* > *Flutter* > *Export All Widgets* )，然后设置想要的附加选项即可。
-
-This creates a series of classes in the lib/ subdirectory of your project, which you can then use directly. You can continue to tweak the XD prototype and export again with ⇧⌘F (Ctrl+Shift+F on Windows) and, if you have enabled the Dart [*Hot Reload on Save Watcher *setting](https://dartcode.org/docs/settings/#dartpreviewhotreloadonsavewatcher) in Visual Studio Code, your app automatically reloads with any updates when you re-export the widgets.
 
 这个操作会在项目的 lib/ 子文件夹中创建一系列的类，您可以直接使用。您也可以继续调整 XD 原型，然后用 ⇧⌘F (在 Windows 上是 Ctrl+Shift+F) 再次导出，如果您在 Visual Studio Code 中打开了 Dart 的 "[在 Save Watcher 上使用热重载](https://dartcode.org/docs/settings/#dartpreviewhotreloadonsavewatcher)" 选项，那么当您重新导出 widget 时，您的应用将自动重新加载它们。
 
@@ -68,11 +46,8 @@ This creates a series of classes in the lib/ subdirectory of your project, which
 
 △ 从 XD 快速转出代码的功能，使得从原型到应用之间的路径又多了一条
 
-As an early access preview, there are of course some limitations, which are described in the [release notes](https://github.com/AdobeXD/xd-to-flutter-plugin/blob/master/README.md). One notable limitation is that responsive layout is not yet available, pending completion of a new XD API. But you’ll automatically get updates to the plugin as new features like this become available.
-
 作为早期体验的预览版，这个插件现在也有一些限制，请阅读 [发布说明](https://github.com/AdobeXD/xd-to-flutter-plugin/blob/master/README.md#using-this-plugin) 了解详情。值得注意的是，响应式布局目前还不能使用，尚需等待新的 XD API 完成。不过请放心，当这些新功能上线时，您会自动获得插件更新。
 
->  *“At Adobe, we’re always looking to simplify the designer-to-developer workflow that pains so many teams designing and building apps. Today, we’re excited to release an early access preview of the work that’s come out of our partnership with Flutter to remove guesswork, accelerate decision making, and help teams bring new experiences to market faster.”* - Vijay Vachani, Senior Director of Creative Cloud Platform & Ecosystem, Adobe
 
 > Adobe 致力于帮助那些设计和打造应用的团队，简化让他们颇为困扰的设计-开发流程。今天我们很高兴推出这个全新工具的早期体验版，它诞生自我们与 Flutter 的合作，旨在消除设计-开发流程中含糊的沟通环节，提高决策速度，便于团队更快地将新体验推向市场。
 —— Vijay Vachani, Adobe Creative Cloud 平台与生态资深总监

--- a/src/posts/announcing-flutter-1-12.md
+++ b/src/posts/announcing-flutter-1-12.md
@@ -3,356 +3,182 @@ title: Flutter 1.12 正式发布，为这一年画上圆满的句号！
 description: Flutter 1.12 正式发布，包括多项性能改进等。
 ---
 
-Posted by Chris Sells, Product Manager, Flutter developer experience*
-
-作者 / Chris Sells，Flutter 开发者体验产品经理*
-
-Today we're pleased to announce version 1.12, the latest stable Flutter release. This makes 5 stable releases since our 1.0 release in December, 2018. It's been an amazing year! We've closed 5,303 issues and merged 5,950 pull requests from 484 contributors. In the Flutter engine and framework, we've added support for Android App Bundles, iOS 13, implemented mouse and keyboard events, released the In-App Purchase plugin, merged [several](https://github.com/flutter/engine/pull/12385) [important](https://github.com/flutter/flutter/pull/36482) [performance](https://github.com/flutter/engine/pull/10182) [improvements](https://github.com/flutter/flutter/pull/37275), localized for 24 additional locales and created several new widgets. Furthermore, the Flutter tools have seen a great deal of improvement as well, with the release of Dart DevTools, which provides the widget inspector, memory and CPU profiling, and enhanced logging that can be used regardless of your editor/IDE of choice. Also, we've added auto-import of packages for referenced types, explicit ChromeOS support, UI Guides to make your build methods easier to read and write, and improved error messages with formatting, colors and more actionable wording.
+*作者 / Chris Sells，Flutter 开发者体验产品经理*
 
 我们很高兴正式推出 Flutter 最新稳定版: Flutter 1.12。自从去年 12 月发布 Flutter 1.0 以来，这已经是我们发布的第 5 个稳定版本了。多么精彩的一年！我们一共解决了 5,303 个报错，合并了来自 484 位贡献者的 5,950 份 pull request。我们在 Flutter 引擎和框架中添加了对 Android App Bundles、iOS 13 和 web 的支持，实现了鼠标与键盘事件，发布了应用内购插件，融合了[多项](https://github.com/flutter/engine/pull/12385)[重要](https://github.com/flutter/flutter/pull/36482)的[性能](https://github.com/flutter/engine/pull/10182)[改进](https://github.com/flutter/flutter/pull/37275)，还新增了 24 种语言支持和多个 widget。
 此外，随着 Dart DevTools 的发布，Flutter 开发工具也比之前更为强劲。Dart DevTools 内含 widget 检查器以及内存与 CPU 性能分析工具，而且优化后的日志功能在所有编辑器和 IDE 中都能流畅运行。此外，我们还针对引用类型添加了代码包自动导入功能，加入了 ChromeOS 显式支持以及 UI Guide，让您的构建方法更易读写，并从排版、配色和可操作性三方面对 Flutter 的错误信息进行了优化。
 
-And with each release, we've said the same thing --- that we're just getting started. This continues to be true in this, our biggest release yet, coming from 188 contributors, closing 4,571 issues and merging 1,905 PRs. As in previous releases, enhancements abound for both the Flutter framework, and the tooling.
-
 我们每次推出新版本的时候都会反复强调: 这是一个新的开始。Flutter 1.12 自然也不例外，作为我们到目前为止最大的一次版本更新，1.12 包含了 188 位贡献者的辛勤付出，解决了 4,571 个报错，合并了 1,905 份 pull request。与之前发布的版本类似，本次更新也包含了大量针对 Flutter 框架和开发工具的改进。
-
-**Flutter framework**
 
 **Flutter 框架**
 
-This release includes a visual refresh to support iOS 13 that includes completed implementation of Dark Mode, new Cupertino widgets, several UX tweaks, and a greatly enhanced Add-to-App experience.
-
 为更好地支持 iOS 13，Flutter 1.12 在视觉效果方面进行了全面更新，其中包括深色模式 (Dark Mode) 完整实现、全新的 Cupertino widget，多项 UX 微调以及增强版 Add-to-App 体验。
 
-**iOS 13 dark mode completed**
-
 **全面支持 iOS 13 深色模式**
-
-More big news in Flutter 1.12 is the completion of our work to support the iOS 13 look and feel. This includes complete dark mode support in the Cupertino widgets.
 
 Flutter 1.12 带来的一个重磅消息是，我们现已支持 iOS 13 风格的界面和操作。这包括在 Cupertino widget 中对深色模式的全面支持。
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot12-release/ios-13-dark-mode.png){:width="60%"}
 
-If you'll notice in the screen shots above, dark mode support is much more than just swapping out the background color, but also adapting the rest of the colors to be a good match. Such deep attention to dark mode was a huge amount of work, but worth it to get pixel-perfect iOS design support across both dark and light mode.
-
 仔细观察上图您会发现，如果想要支持深色模式，可不是单单换个背景颜色就大功告成了，必须要让屏幕上的其它颜色也适应偏暗的色调才行。这些细节处理为开发者带来了巨大的工作量，但是为了在深色和浅色模式下都能呈现出精美的 Cupertino 风格外观，这些努力都是值得的。
-
-Also, in our continuing goal for pixel-perfection for iOS 13, we've added two new widgets.
 
 在 iOS 13 上实现像素级完美是我们一直在努力的目标，为此，我们在 Flutter 1.12 中新增了 2 个 widget。
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot12-release/cupertino-context-menu-and-cupertino-sliding-segmented-control.png){:width="60%"}
 
-[CupertinoContextMenu](https://api.flutter.cn/flutter/cupertino/CupertinoContextMenu-class.html) and [CupertinoSlidingSegmentedControl](https://api.flutter.cn/flutter/cupertino/CupertinoSlidingSegmentedControl-class.html)
-
-And finally, in our quest to make a Flutter app feel as well as look native on iOS 13, we've [improved scrollbar fidelity](https://github.com/flutter/flutter/pull/41799), [provided for adaptive CupertinoAlertDialog padding](https://github.com/flutter/flutter/pull/42967), and [allowed for min/max date constraints on the CupertinoDatePicker](https://github.com/flutter/flutter/pull/44149).
+[CupertinoContextMenu](https://api.flutter.cn/flutter/cupertino/CupertinoContextMenu-class.html) 和 [CupertinoSlidingSegmentedControl](https://api.flutter.cn/flutter/cupertino/CupertinoSlidingSegmentedControl-class.html)
 
 最后，为了让 Flutter 应用能在 iOS 13 设备上实现原生级别的界面和操作感受，我们还[提高了滚动条保真度](https://github.com/flutter/flutter/pull/41799)，[提供了自适应对话框弹出模式 CupertinoAlertDialog](https://github.com/flutter/flutter/pull/42967)，并在 [CupertinoDatePicker 内添加了最小/最大日期约束](https://github.com/flutter/flutter/pull/44149)。
 
-**Add-to-App updated**
-
 **Add-to-App 更新**
-
-Another improvement in our mobile support is an update to Add-to-App, which is the ability to integrate Flutter into an existing Android or iOS app. Here, we've been working on simplifying the integration flow to make adding a Flutter library to your app a better experience, including the addition of a new Flutter Module wizard in Android Studio.
 
 Add-to-App 功能更新是我们在移动支持方面所做的另一项改进。通过 Add-to-App，开发者可以将 Flutter 集成到现有的 Android 或 iOS 应用中。我们一直在努力简化集成流程，让您可以更轻松地把 Flutter 代码库添加到应用中，比如说，我们在 Android Studio 中添加了一个全新的 Flutter 模块向导。
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot12-release/flutter-module.png){:width="70%"}
 
-With Flutter 1.12, Add-to-App is now officially supported for adding one fullscreen Flutter instance to your app. In supporting this functionality, we've also:
-
 Flutter 1.12 现已正式支持 Add-to-App 功能，允许开发者在应用中添加一个全屏 Flutter 实例。在支持这个功能的同时，我们还: 
 
--   Stabilized the APIs for platform integration in Java, Kotlin, Objective-C and Swift, including a new set of APIs for Android. See [the Android project migration docs](https://flutter.cn/go/android-project-migration) for details on changes.
-
-    提高了 API 稳定性，以便在平台中集成 Java、Kotlin、Objective-C 和 Swift 代码，其中包括一套全新的 Android API。请参阅 [Android 项目迁移说明](https://flutter.cn/go/android-project-migration)，了解变更细节。
-
--   Added support for using plugins in embedded Flutter modules.
-
-    支持在内嵌 Flutter 模块中使用插件。
-
--   Provided additional integration mechanisms via [Android AARs](https://flutter.cn/docs/development/add-to-app/android/project-setup#option-a---depend-on-the-android-archive-aar) and [iOS Frameworks](https://flutter.cn/docs/development/add-to-app/ios/project-setup#option-b---embed-frameworks-in-xcode) for better compatibility with existing build systems.
-
-    通过 [Android AAR](https://flutter.cn/docs/development/add-to-app/android/project-setup#option-a---depend-on-the-android-archive-aar) 和 [iOS 框架提供额外的集成机制](https://flutter.cn/docs/development/add-to-app/ios/project-setup#option-b---embed-frameworks-in-xcode)，以提高与现有构建系统的兼容性。
-
--   Reworked the 'flutter attach' mechanism on the command-line tools, VSCode and IntelliJ plugins to easily attach onto a running Flutter module for debugging, DevTools and hot reload.
-
-    更新了命令行工具、VSCode 和 IntelliJ 插件中的 "flutter attach" 机制，方便开发者接入正在运行的 Flutter 模块，并进行调试，使用 DevTools 或者进行热重载。    
-
-To try Add-to-App, see the [website documentation](https://flutter.cn/docs/development/add-to-app) or browse our [sample projects](https://github.com/flutter/samples/tree/master/experimental/add_to_app) demonstrating various integration scenarios.
+-   提高了 API 稳定性，以便在平台中集成 Java、Kotlin、Objective-C 和 Swift 代码，其中包括一套全新的 Android API。请参阅 [Android 项目迁移说明](https://flutter.cn/go/android-project-migration)，了解变更细节。
+-   支持在内嵌 Flutter 模块中使用插件。
+-   通过 [Android AAR](https://flutter.cn/docs/development/add-to-app/android/project-setup#option-a---depend-on-the-android-archive-aar) 和 [iOS 框架提供额外的集成机制](https://flutter.cn/docs/development/add-to-app/ios/project-setup#option-b---embed-frameworks-in-xcode)，以提高与现有构建系统的兼容性。
+-   更新了命令行工具、VSCode 和 IntelliJ 插件中的 "flutter attach" 机制，方便开发者接入正在运行的 Flutter 模块，并进行调试，使用 DevTools 或者进行热重载。    
 
 如果您想要体验 [Add-to-App](https://flutter.cn/docs/development/add-to-app) 功能，请参阅文档或浏览我们的[示例项目](https://github.com/flutter/samples/tree/master/experimental/add_to_app)，我们在这些项目中展示了多种集成场景。
 
 **Dart 2.7**
 
-Of course, everything we do in Flutter is based on Dart, so if you haven't already read about extension methods and safe string handling (including emojis), or want an update on null safety using non-nullable types, you can find that information in the [Dart 2.7 announcement](https://medium.com/dartlang/dart-2-7-a3710ec54e97).
-
 当然，我们在 Flutter 中所做的一切都是构建在 Dart 的基础上的，所以，如果您还没有听过扩展方法和字符串安全处理 (包含表情符)，或是想要了解非空类型在空安全方面的最新知识，不妨阅读[《Dart 2.7 现已发布》](https://medium.com/dartlang/dart-2-7-a3710ec54e97)进一步了解相关信息。
-
-**Beyond Flutter 1.12 stable**
 
 **在 Flutter 1.12 稳定版之外也同样精彩**
 
-At the same time that Flutter is getting new features in the stable channel, it's also getting new features beyond what you can do in stable, specifically a beta release of web support and an alpha release of macOS support.
-
 Flutter 不仅通过稳定渠道发布了许多全新功能，稳定版之外亦是精彩纷呈，尤其是 Beta 版本的 web 支持以及 Alpha 版本的 macOS 支持。
 
-**Web support available in beta**
-
 **Beta 版 web 支持**
-
-The Flutter 1.12 master, dev and beta channels all provide improved support for web.
 
 Flutter 1.12 master、dev 和 beta 三个渠道所提供的 web 支持均有明显提升。
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot12-release/support-for-web.png){:width="95%"}
 
-One happy customer of Flutter on the web is [Rivet](https://rivet.area120.com/link/flutter), pictured above. Rivet is an education project that currently has a mobile app in production. They're using Flutter and Firebase to build a web version of their app that they plan to launch in early 2020.
-
 [Rivet](https://rivet.area120.com/link/flutter) (应用界面如上图所示) 对 Flutter 在 web 端的表现非常满意。Rivet 是一个教育项目，旗下的移动版应用已经发布，目前，他们正在使用 Flutter 和 Firebase 构建 web 版本的应用，预计发布时间为 2020 年 1 月。
-
-You can learn more about what other customers are doing with Flutter's web support as well as the rest of the details in the [Flutter web blog post](https://medium.com/flutter/web-support-for-flutter-goes-beta-35b64a1217c0).
 
 请阅读这篇 [Flutter web 支持文章](https://medium.com/flutter/web-support-for-flutter-goes-beta-35b64a1217c0)，进一步了解其他开发者的 Flutter web 故事。
 
-**macOS moving to alpha**
-
 **macOS 端支持进入 alpha 版本**
-
-macOS desktop support isn't far behind, moving from tech preview to alpha, available now in both master and dev channels (in Flutter SDK 1.13).
 
 macOS 桌面支持的进展也很顺利，现在已经从技术预览版迭代至 alpha 版，并通过 master 和 dev 两个渠道开放下载。
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot12-release/macos-desktop-support.png){:width="95%"}
 
-Pictured here at desktop size is [a new version of the Flutter Gallery](https://flutter.github.io/samples/#/) that's been completely updated to support macOS in addition to Android, iOS, and web.
-
 上图展示的是桌面尺寸的[新版 Flutter Gallery](https://flutter.github.io/samples/#/)，经过彻底升级，现在它已经支持 Android、iOS、web 和 macOS。
-
-The macOS alpha represents a big step forward for Flutter's desktop support, including the new DataTree and Split sample widgets, several plugins ported to macOS, support for building in both release and profiling mode, and a greatly simplified tooling story. If you're running from the dev or master channel, you can gain access to the macOS tooling by enabling macOS desktop support in Flutter's system-wide config:
 
 macOS 端支持的 alpha 版代表着 Flutter 在桌面支持领域的重大进展，其中包括全新的 DataTree、Split 示例 widget、已成功移植至 macOS 的多个插件、发布 (release mode) 和分析模式 (profiling mode) 内的构建支持、以及更为简便的工具体验。如果您通过 master 和 dev 渠道运行 Flutter，请在 Flutter 系统配置中启用 macOS 桌面端支持，以便获取 macOS 工具:
 
 `$ flutter config --enable-macos-desktop`
 
-Creating a Flutter project that runs on macOS is now just like creating any other new Flutter project with 'flutter create'.
-
 现在，您只需通过 "flutter create" 命令就能创建一个可在 macOS 平台上运行的 Flutter 项目，操作步骤和新建一个普通的 Flutter 项目一样简单。
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot12-release/flutter-create.png){:width="95%"}
 
-Notice the new macos directory created by default
-
 △ 请注意默认创建的新 macOS 目录
-
-In addition to the tooling support, we've also been working on the density that's appropriate for desktop-sized apps. Mobile apps need relatively large controls to accommodate touch interactions whereas on desktop-sized devices, a user is more likely to be using a mouse. In bringing Flutter to the desktop, we've worked on allowing you to choose the density of your widgets to better accommodate the needs of your desktop users:
 
 除了工具支持之外，我们也在一直探索适合桌面级应用的 widget 密度。移动应用需要较大的控制区域才能正常进行触控操作，但在桌面应用中，用户更可能会使用鼠标。为了把 Flutter 带到桌面，我们现在允许您选择 widget 密度，以便更好地满足桌面用户的需求。
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot12-release/sample-demonstrating-flutters-implementation-of-the-material-density-guidelines.gif){:width="60%"}
 
-[Sample](https://github.com/gspencergoog/density_sample) demonstrating Flutter's implementation of [the Material Density guidelines](https://material.io/design/layout/applying-density.html)
-
 [示例](https://github.com/gspencergoog/density_sample): [Material 视觉密度设计规范](https://material.io/design/layout/applying-density.html)在 Flutter 上的实现 
-
-And finally, to improve the experience of Flutter desktop apps, we've done a lot of work on keyboard navigation and keyboard access, including:
 
 最后一点，为了改善 Flutter 桌面应用的体验，我们还在键盘导航和键盘访问方面做了不少工作，包括:
 
--   [synchronizing modifier keys with key events](https://github.com/flutter/flutter/pull/43948)
-
-    [在按键事件中同步修饰键信息](https://github.com/flutter/flutter/pull/43948)
-
--   [managing item selection when a dropdown is opened](https://github.com/flutter/flutter/pull/43722)
-
-    [在下拉列表打开时管理项目选取](https://github.com/flutter/flutter/pull/43722)
-
--   [adding a convenience accessor for primary focus](https://github.com/flutter/flutter/pull/43859)
-
-    [为主焦点添加便利访问器](https://github.com/flutter/flutter/pull/43859)
-
--   [adding keyboard navigation, hover and shortcuts for switches](https://github.com/flutter/flutter/pull/43384)
-
-    [为切换控件添加键盘导航、悬浮和快捷方式](https://github.com/flutter/flutter/pull/43384)
-
--   [checkboxes and radio buttons](https://github.com/flutter/flutter/pull/43384)
-
-    [勾选框和单选按钮](https://github.com/flutter/flutter/pull/43384)
-
--   [automatic scrolling to keep focused items in view](https://github.com/flutter/flutter/pull/44965)
-
-    [自动滚动以便让焦点项维持在视野内](https://github.com/flutter/flutter/pull/44965)
-
--   [keyboard shortcut-based scrolling](https://github.com/flutter/flutter/pull/45019)
-
-    [基于键盘快捷方式的滚动](https://github.com/flutter/flutter/pull/45019)
-
--   [a new widget for handling focus and hover](https://github.com/flutter/flutter/pull/44867)
-
-    [处理焦点和悬浮的新 widget](https://github.com/flutter/flutter/pull/44867)
-
--   [rewritten copy/paste and keyboard selection](https://github.com/flutter/flutter/pull/44130)
-
-    [重写复制/粘贴和键盘选取](https://github.com/flutter/flutter/pull/44130)
-
--   [keyboard navigation of dropdowns](https://github.com/flutter/flutter/pull/42811)
-
-    [下拉列表键盘导航](https://github.com/flutter/flutter/pull/42811)
-
--   [visual density support](https://github.com/flutter/flutter/pull/43547)
-
-    [视觉密度支持](https://github.com/flutter/flutter/pull/43547)
-
--   [adding macOS function key support](https://github.com/flutter/flutter/pull/44410)
-
-    [添加 macOS 功能键支持](https://github.com/flutter/flutter/pull/44410)
-
-In addition to the Flutter sample, we also recommend [the new Photos Search sample](https://github.com/flutter/samples/tree/master/experimental/desktop_photo_search), which shows off a lot of desktop goodness, including keyboard handling, the new widget density, the new plugins, and the new widgets.
+-   [在按键事件中同步修饰键信息](https://github.com/flutter/flutter/pull/43948)
+-   [在下拉列表打开时管理项目选取](https://github.com/flutter/flutter/pull/43722)
+-   [为主焦点添加便利访问器](https://github.com/flutter/flutter/pull/43859)
+-   [为切换控件添加键盘导航、悬浮和快捷方式](https://github.com/flutter/flutter/pull/43384)
+-   [勾选框和单选按钮](https://github.com/flutter/flutter/pull/43384)
+-   [自动滚动以便让焦点项维持在视野内](https://github.com/flutter/flutter/pull/44965)
+-   [基于键盘快捷方式的滚动](https://github.com/flutter/flutter/pull/45019)
+-   [处理焦点和悬浮的新 widget](https://github.com/flutter/flutter/pull/44867)
+-   [重写复制/粘贴和键盘选取](https://github.com/flutter/flutter/pull/44130)
+-   [下拉列表键盘导航](https://github.com/flutter/flutter/pull/42811)
+-   [视觉密度支持](https://github.com/flutter/flutter/pull/43547)
+-   [添加 macOS 功能键支持](https://github.com/flutter/flutter/pull/44410)
 
 除了 Flutter Gallery，我们还推荐大家去看一下[全新的 Photos Search 示例应用](https://github.com/flutter/samples/tree/master/experimental/desktop_photo_search)，我们在其中展示了桌面平台特有的强大功能，包括键盘操作、新加入的 widget 视觉密度、新插件、新 widget 等。
 
-For those of you curious about progress on Windows and Linux, they're still in technical preview, but both benefit from a lot of the work to get macOS to alpha. We'll share the updates to those platforms soon. For more details of where we are with desktop support in Flutter for macOS, Windows and Linux, please see [flutter.cn/desktop](https://flutter.cn/desktop).
-
 至于 Windows 和 Linux 支持，它们目前还处在技术预览阶段，不过，macOS alpha 版的开发经历很多值得借鉴的地方，有助于我们之后开展 Windows 和 Linux 的工作。我们近期就会和大家分享关于这两个平台的最新消息。如果您想进一步了解 Flutter 为 macOS、Windows 和 Linux 等桌面系统提供了哪些支持，请移步 [flutter.cn/desktop](https://flutter.cn/desktop)。
 
-**Flutter tooling**
-
-**Flutter 开发工具**
-
-In addition to the Framework and Engine, we also have a lot to talk about for Flutter tooling. This includes a new version of DartPad with support for Flutter, augmented IntelliJ-based IDEs with a preview of a new feature we're calling "Hot UI", enhanced Dart DevTools with a new visual layout view, enabled simultaneous multi-device debugging in Visual Studio Code, improved the Android build process and better support for finding differences in rendered widgets between test runs.
+**Flutter 工具**
 
 除了框架和引擎之外，我们在 Flutter 工具方面也有许多内容想与您分享，包括: 提供 Flutter 支持的新版本 DartPad、基于 IntelliJ 的增强版 IDE (内含新功能 Hot UI 的预览)、强化版 Dart DevTools (内含全新的视觉布局视图)、Visual Studio Code 同步多设备调试启用，以及改进版 Android 构建流程，此外，我们提供了更好的差异检测支持，帮助您检测已渲染 widget 在不同试运行中差异。
 
-**DartPad loves Flutter**
-
 **DartPad 现已支持 Flutter**
 
-If you aren't already using [DartPad](https://dartpad.dev/), you should try it out! It's a great way to try Dart features without installing anything. Furthermore, with the new release of DartPad, now you get Flutter, too!
-
-如果您还没用过 [DartPad](https://dartpad.dev/) 的话，不妨现在就上手试试！有了它，您不用安装任何工具就能体验 Dart 的功能。此外，最新的 DartPad 还支持 Flutter！
+如果您还没用过 [DartPad](https://dartpad.cn/) 的话，不妨现在就上手试试！有了它，您不用安装任何工具就能体验 Dart 的功能。此外，最新的 DartPad 还支持 Flutter！
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot12-release/dartpad.png){:width="95%"}
 
-The new DartPad leverages Flutter's web support so that when you're writing Flutter code on the left, you're running a real, live Flutter (web) program on the right. The chief difference is that using DartPad, you can get started with Flutter without installing a thing.
-
 全新的 DartPad 活用了 Flutter 的 web 端支持，当您在左侧编写 Flutter 代码的时候，右侧就会实时运行一个真实的 Flutter (web) 程序。DartPad 的独特之处在于，您无需安装任何程序就能立即开始编写 Flutter 应用。
-
-In addition to the stand-alone DartPad playground, we've also started adding DartPad with Flutter support into our docs and in our codelabs (like [Basic Flutter layout concepts](https://flutter.cn/docs/codelabs/layout-basics) and [Implicit animations](https://flutter.cn/docs/codelabs/implicit-animations)), so that you can learn about Flutter from the comfort of your browser. For more information on DartPad, please check out our [DartPad announcement post](https://medium.com/dartlang/a-brand-new-dartpad-dev-with-flutter-support-16fe6027784).
 
 除了单独的 DartPad 网站之外，我们还在文档和 codelab (如 "Flutter [布局基础教程](https://flutter.cn/docs/codelabs/layout-basics)" 和 "[隐式动画](https://flutter.cn/docs/codelabs/implicit-animations)") 中加入了带 Flutter 支持的 DartPad，从而方便大家在浏览器中学习 Flutter。如果您想要了解更多关于 DartPad 的信息，请阅读《[DartPad.dev 全面升级，现已支持 Flutter](https://medium.com/dartlang/a-brand-new-dartpad-dev-with-flutter-support-16fe6027784)》。
 
-**Build your widgets inline with Hot UI**
-
 **在 IDE 中通过 Hot UI 直接构建 widget**
-
-If you install the Flutter tools locally on your own machine (and we hope you will), you'll find a new feature previewed in the IntelliJ/Android Studio plugin for Flutter. It allows you to see and interact with your widgets directly in your IDE as you're building them.
 
 如果您在自己的机器上安装了本地工具 (我们也希望您这么做)，您会在 Flutter 的 IntelliJ/Android Studio 插件中找到一个新功能预览。现在您可以在开发 widget 的过程中，直接在 IDE 里进行预览并与之进行交互。
 
-We call this feature "Hot UI" and, like Hot Reload, as you make the changes in your code, it updates the hosted UI directly. You can also interact with the hosted UI (like changing a color, as shown here) and that change goes directly into your code. To enable the Hot UI preview, you can [read the instructions on the Flutter wiki](https://github.com/flutter/flutter-intellij/wiki/HotUI-Getting-Started-instructions).
-
 我们把这个功能起名为 Hot UI，它与热重启有点类似，当您在代码中做出改动的时候，Hot UI 就会直接更新对应的 UI。您也可以和 UI 进行互动 (比如像上图中这样更改颜色)，所有改动会直接写入代码。如需启用 Hot UI 预览功能，请阅读 [Github Flutter wiki 页面上的操作指南](https://github.com/flutter/flutter-intellij/wiki/HotUI-Getting-Started-instructions)。
 
-**Debug layout issues with the Layout Explorer**
-
 **使用 Layout Explorer 调试布局问题**
-
-Whether you write the code by hand or let Hot UI write it for you, you've still got code and sometimes code has issues. Helping you track down and fix your issues is exactly why Dart DevTools was invented. In this new version of DevTools, we've added a feature called the "Layout Explorer" to augment the Inspector with a visual representation of your layout.
 
 无论您是选择自己手写代码，还是让 Hot UI 替写，代码中出现问题总是难免的。我们推出 Dart DevTools 工具的目的就是，帮助您找到并修复这些问题。在新版 DevTools 中，我们添加了一个名为 Layout Explorer 的功能，它能够以可视化的方式呈现应用的布局信息，从而让检查器可以更好地发挥功能。
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot12-release/layout-explorer.gif){:width="95%"}
 
-Not only does the Layout Explorer help you to visualize the layout of the widgets in your running app, but if you'd like to experiment with changing the layout options, it allows you to do so interactively. We're hoping the preview of this feature helps make it easier to understand and fix your layout issues. To enable this feature, see [the Layout Explorer docs](https://flutter.cn/docs/development/tools/devtools/inspector#flutter-layout-explorer).
-
 Layout Explorer 不仅能以可视化的方式展现正在运行的应用中的 widget 布局，而且还允许您以交互的方式更改布局选项。我们希望这个功能预览可以让您更容易理解并修正布局问题。如需启用这一功能，请参阅 [Layout Explorer 官方文档](https://flutter.cn/docs/development/tools/devtools/inspector#flutter-layout-explorer)。
 
-**Multi-device debugging**
-
 **多设备调试**
-
-When you've built and debugged your Flutter UI, you have most likely done it on a single device. Wouldn't it be nice to be able to debug your app across multiple devices (physical or virtual) at the same time? With Flutter's support for multi-session debugging in Visual Code, that's just what you can do.
 
 构建并调试 Flutter UI 的工作往往是在同一台设备上完成的。如果能同时在多台实体或虚拟的设备上调试您的应用，是不是会更好呢？Flutter 在 Visual Code 上提供的多会话调试支持就能帮您做到这一点。
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot12-release/multi-device-debugging.png){:width="95%"}
 
-Here we've got the same Flutter app running simultaneously on three separate debugging sessions. If we make a change in the code, Hot Reload makes sure that it's reflected in all three apps. If we set a breakpoint, whichever app triggers that code gets stopped. If you'd like to stop debugging one, you can do so without stopping them all. You can learn how to configure this feature for [multiple device debugging on the wiki](https://github.com/flutter/flutter/wiki/Multi-device-debugging-in-VS-Code).
-
 从上面这张图里我们可以看到，一个 Flutter 应用正同时运行在 3 个不同的调试会话中，如果我们在代码中做出一处更改，Hot Reload 会确保这个更改反映在所有 3 个应用中。如果我们设置一个断点，那么无论哪个应用触发了相关代码，它都会停下来。如果您想中止某一个会话的调试，也不需要停止所有的会话。请前往 Github wiki 页面了解如何配置这个功能来实现[多设备调试](https://github.com/flutter/flutter/wiki/Multi-device-debugging-in-VS-Code)。
-
-**Android build improvements**
 
 **Android 构建改进**
 
-And finally, to continue to improve Android, we addressed some build problems in this release. Firstly, we made the Android build more robust, specifically around combining plugins using Support Libraries and those using AndroidX. We did this by moving the Flutter team's plugins to AndroidX and [we recommend that apps and plugins move to AndroidX as well](https://flutter.cn/docs/development/packages-and-plugins/plugin-api-migration). However, for plugins that haven't yet moved, if there is a build problem, we have an alternate code path in our build that uses Android Archive files and Jetifier. The build is slower, which is why it's not the primary build mechanism, but we find that it solves about 95% of the build problems we've encountered.
-
 最后一点，为了继续改进 Android，我们在新版本中解决了一些构建方面的问题。首先，我们让 Android 构建体验更加强健了，尤其是使用 Support 库的插件与使用 AndroidX 的插件混用的情况。我们的做法是把 Flutter 团队的插件移入 AndroidX，我们[建议大家把应用和插件也迁移至 AndroidX](https://flutter.cn/docs/development/packages-and-plugins/plugin-api-migration)。对于那些尚未迁移的插件，如果存在构建问题，我们已经在构建中添加了其它的代码路径，这个路径使用的是 Android Archive 文件和 Jetifier。但如此一来构建的速度也减慢了，所以我们不把它作为主要的构建机制，但我们发现，这个做法解决了我们遇到的大约 95% 的构建问题。
 
-Another issue we addressed was deprecating Proguard in favor of [R8](https://developer.android.com/studio/build/shrink-code), the new code optimizer from Google. Before this release, the app author had to configure ProGuard rules manually using guidance provided by the plugin author. In this release, plugins can define their rules in the source code and R8 consumes these rules automatically, saving the app developer that headache.
-
-我们解决的另一个问题使用 Google 旗下的最新代码优化器 [R8](https://developer.android.google.cn/studio/build/shrink-code) 来替代 ProGuard。在此版本之前，应用开发者必须按照插件作者提供的指南手动配置 ProGuard 规则。在从新版本开始，插件可在源代码中定义规则，R8 会自动根据这些规则进行代码优化，从而为开发者解决了手动配置的难题。
-
-Furthermore, in our attempt to continue to make Flutter as slim as possible, we reduced the Hello, World app size for Android by 2.6% (reducing it from 3.8MB to 3.7MB). Every little bit helps!
+我们解决的另一个问题使用 Google 开发的最新代码优化器 [R8](https://developer.android.google.cn/studio/build/shrink-code) 来替代 ProGuard。在此版本之前，应用开发者必须按照插件作者提供的指南手动配置 ProGuard 规则。在从新版本开始，插件可在源代码中定义规则，R8 会自动根据这些规则进行代码优化，从而为开发者解决了手动配置的难题。
 
 此外，我们也在一直努力减少 Flutter 的应用体积，现在，供 Android 使用的 Hello, World 应用已经成功 "瘦身" 2.6% (从 3.8MB 降到 3.7MB)。不积跬步，无以至千里！
 
-**Golden image testing**
-
 **Golden 图像测试**
-
-The term "golden image" refers to a master image file that is considered the true rendering of a given widget, state, application, or other visual representation you have chosen to capture. In Flutter 1.12, we have implementations of the [GoldenFileComparator](https://api.flutter.cn/flutter/flutter_test/GoldenFileComparator-class.html) and [LocalFileComparator](https://api.flutter.cn/flutter/flutter_test/LocalFileComparator-class.html) classes that compare by pixels instead of bits, [eliminating false positives](https://github.com/flutter/flutter/issues/30036). These new implementations highlight visual differences to make it clear when there are differences between your golden image and the updates under testing.
 
 Golden 图像指的是一个主图像文件，它是 widget、state、应用或其它您选择捕捉的视觉内容的正确渲染结果。在 Flutter 1.12 中，我们实现了 [GoldenFileComparator](https://api.flutter.cn/flutter/flutter_test/GoldenFileComparator-class.html) 和 [LocalFileComparator](https://api.flutter.cn/flutter/flutter_test/LocalFileComparator-class.html) 类，它们依照像素而不是比特来进行比较，因此可以彻底消除错误的比较结果。这些新的实现强调呈现视觉差异，从而更清楚地展现出 Golden 图像和正在测试中的更新文件之间的差异。
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot12-release/golden-image-testing.png){:width="60%"}
 
-In this case, it's clear that the differences between the master and the test image are all in the border, making it much easier to track down the discrepancy.
-
 在这个例子中，主图像文件 (上图) 和测试图像文件 (下图) 之间的差异集中在轮廓上，通过差值图 (中图) 可以更容易地看出二者之间的差异。
-
-**Community**
 
 **社区**
 
-In addition to all of the work on Flutter and its associated tooling, the Flutter community continues to take Flutter into new and amazing directions! To see what developers in the community are doing, we've put together a little video.
-
 除了 Flutter 及其工具方面的工作，Flutter 社区还在不断地引领 Flutter 前往令人惊奇的新领域！请查看☟下方视频☟，了解一下社区中的开发者们正在做什么。
-
-We're so lucky to have such a great set of developers in the Flutter community. You make us all proud to be on the Flutter team!
 
 拥有这样一群了不起的开发者，真是 Flutter 社区的一大幸事。您们让全体 Flutter 团队成员深感骄傲！
 
 <iframe src="//player.bilibili.com/player.html?aid=86761188&cid=148257761&page=1" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="560" height="315"> </iframe>
 
-**Flutter Favorite packages**
-
 **Flutter Favorite 代码包**
 
-When we released Flutter 1.0 in December, 2018, there were about 1000 packages on pub.dev that supported Flutter and we thought that was a huge number. As of this writing, that number has increased by more than 6x. With that many options, it's sometimes hard to know which packages to choose. The overall score on pub.dev helps as well as the new [Verified Publishers](https://medium.com/dartlang/verified-publishers-98f05466558a) feature. Now, pub.dev is getting [a rating system](https://medium.com/dartlang/dart-2-7-a3710ec54e97), which should help even more.
-
 当我们在 2019 年 12 月推出 Flutter 1.0 的时候，pub.dev 上大约有 1,000 个代码包支持 Flutter，我们当时认为这个数字很大。现在，这个数字已经增加至 6 倍以上。选择这么多，究竟该用哪个代码包反而成了一件麻烦事。pub.dev 的综合评分系统和全新的 [Verified Publishers (发布者认证)](https://medium.com/dartlang/verified-publishers-98f05466558a) 功能都能帮助大家更好地做出选择。另外，pub.dev 即将迎来[评分系统](https://medium.com/dartlang/dart-2-7-a3710ec54e97)，进一步为大家提供方便。
-
-Still, our users have asked again and again for a set of "recommended" packages and plugins. With that in mind, we're pleased to announce [the Flutter Favorite program](https://flutter.cn/docs/development/packages-and-plugins/favorites).
 
 我们的用户仍在不断要求推出 "官方推荐" 的代码包和插件。为此，我们很高兴地推出 [Flutter Favorite 计划](https://flutter.cn/docs/development/packages-and-plugins/favorites)。
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot12-release/the-flutter-favorite-program.png){:width="30%"}
 
-A Flutter Favorite package (or plugin) is one that we think that you should consider first when building your app. The "we" in that sentence is the Flutter Ecosystem Committee, a group of regionally-diverse individuals picked from the Flutter team at Google and from the Flutter community at large to address issues across the Flutter ecosystem. Their first job was to establish a high quality bar and to identify an initial set of packages that met that quality bar. The authors of those packages are able to use the Flutter Favorite logo in their package documentation. Furthermore, pub.dev has been updated to show the logo in search results and other places.
-
 Flutter Favorite 代码包 (或插件) 是我们认为您在构建应用时的第一选择。这里的 "我们" 指的是 Flutter Ecosystem Committee (Flutter 生态圈委员会)。委员会成员来自各个地区，由 Google 的 Flutter 团队和 Flutter 社区共同推选，他们的目标是解决 Flutter 生态圈中存在的各种问题。委员会要做的第一件事就是建立一个高标准基线，并依照这个标准线挑选出合适的代码包。被选中的代码包的作者可以在代码包说明文档中使用 Flutter Favorite 徽标。此外，pub.dev 在更新后也会在搜索结果等位置显示 Flutter Favorite 徽标。
-
-For details, see [the Flutter Favorite page on flutter.cn](https://flutter.cn/docs/development/packages-and-plugins/favorites). You can also see [the complete list of Flutter Favorite packages on pub.dev](https://pub.dev/flutter/favorites). The bottom line is that if you're an app developer and you see that logo, you should have confidence in that package. If you're a package author and you've been awarded the Flutter Favorite logo, thank you for your contribution to the Flutter ecosystem.
 
 请大家前往 flutter.cn 网站上的 [Flutter Favorite 页面](https://flutter.cn/docs/development/packages-and-plugins/favorites)了解详情。您也可以前往 pub.dev 查看[完整的 Flutter Favorite 代码包列表](https://pub.dev/flutter/favorites)。关键是，如果您是应用开发者，而且您看到了 Flutter Favorite 徽标，那么您就可以认为这个代码包是可以信赖的。如果您是得到 Flutter Favorite 认证的代码包作者，我们非常感谢您对 Flutter 生态圈所做的贡献。
 
-**Community tools**
-
 **来自社区的工具**
-
-And speaking of contributions to be proud of, the Flutter community at large has been building a number of excellent tools as well; here's just a selection.
 
 谈到值得骄傲的贡献，就不得不说 Flutter 社区打造的众多出色工具。我们在下面列举部分成果。
 
@@ -368,37 +194,21 @@ And speaking of contributions to be proud of, the Flutter community at large has
 
 [Panache](https://rxlabz.github.io/panache/#/)
 
-**Featured tooling partner: Nevercode**
-
 **工具开发伙伴鸣谢: Nevercode**
-
-In addition to a great set of community tools, the Flutter ecosystem has a great set of tooling partners as well. One notable partner has always been Nevercode, who have a whole new set of features in their latest release, including [a Visual Studio Code plugin called Remote Mac](https://marketplace.visualstudio.com/items?itemName=codemagic.remote-mac).
 
 Flutter 生态圈不仅包括由社区开发的丰富工具，还有一批很棒的工作开发伙伴。Nevercode 一直以来都是我们的重要合作伙伴之一，他们最新发布的工具提供了许多新功能，其中一项就是名为 [Remote Mac 的 Visual Studio Code 插件](https://marketplace.visualstudio.com/items?itemName=codemagic.remote-mac)。
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot12-release/remote-mac.png){:width="95%"}
 
-The Remote Mac extension lets you connect directly to a Mac that they've hosted in the cloud for purposes of testing your iOS and macOS Flutter code. For more details about Nevercode's latest release, including new support for Flutter on the web and on macOS, new enterprise features and more, check out [their newest blog post](https://blog.codemagic.io/more-professional-capable-accessible/).
-
 Remote Mac 扩展插件可以让您直接连上一台由团队托管在云端的 Mac 主机，然后测试 iOS 和 macOS 版本的 Flutter 代码。如果您想要了解更多关于 Nevercode 最新产品的信息，例如对 web 端和 macOS 端 Flutter 的最新支持，全新的企业功能等等，请参阅他们[最新发布的博文](https://blog.codemagic.io/more-professional-capable-accessible/)。
-
-To see the progress being made by our other tooling partners, you should definitely [check out what Supernova, Rive and Adobe are up to in their latest releases](https://developers.googleblog.com/2019/12/flutter-ui-ambient-computing.html).
 
 其他工具开发伙伴们的进展也不容错过，欢迎阅读《[Flutter: 首个面向环境计算打造的 UI 平台](https://developers.googleblog.com/2019/12/flutter-ui-ambient-computing.html)》了解 Supernove、2Dimensions 和 Adobe 最新发布的产品。
 
-**Conclusion**
-
 **结语**
-
-This has definitely been a big year for Flutter and v1.12 is a big release. This blog post has been a whirlwind tour of what's new in this release; if you'd like to check on your favorite pull release, see where we've been spending our time in this release by how many pull releases in each area or see what we broke, then we recommend [the Flutter 1.12 Release Notes](https://flutter.cn/docs/development/tools/sdk/release-notes/release-notes-1.12.13).
 
 今年对于 Flutter 来说是非常重要的一年，Flutter 1.12 更是一次意义重大的发布。本文大致为大家展示了本次发布版本中的新内容；如果您想要查看您最喜欢的 pull release，了解我们把精力投放在了哪些地方，想要看看每个领域中有多少 pull release，或者看看我们在代码和功能上做了哪些改动，欢迎查阅 [Flutter v1.12 发布说明](https://flutter.cn/docs/development/tools/sdk/release-notes/release-notes-1.12.13)。
 
-We hope you agree that Flutter is moving in the right direction and picking up speed. With all of these new features and new tools, where do you want your app to run today?
-
 我们认为 Flutter 正朝着正确的方向快步前进，希望您也同意我们的看法。拥有这么多的新功能和新工具之后，您会构建什么呢？我们拭目以待。
-
-English Placehodler
 
 文/ [Flutter Blog](https://medium.com/flutter/announcing-flutter-1-12-what-a-year-22c256ba525d)，
 译/ [谷歌开发者](https://mp.weixin.qq.com/s/sETtUi-J4cxCCbKP_FQkpA)

--- a/src/posts/announcing-flutter-1-20.md
+++ b/src/posts/announcing-flutter-1-20.md
@@ -1,414 +1,214 @@
 ---
-title: Announcing Flutter 1.20
 title: Flutter 1.20 正式发布
-description: Performance improvements, mobile autofill, a new widget and more!
 description: 性能改进、移动端自动填充、全新 widget 以及更多内容！
 toc: true
 ---
 
 ![](https://devrel.andfun.cn/devrel/posts/2020/08/bbbf90037ad95.png){:max-width="90%"}
 
-Chris Sells
-
 作者 / Chris Sells, Product Manager, Flutter developer experience
-
-Our ongoing vision with Flutter is to provide a portable toolkit for building stunning experiences wherever you might want to paint pixels on the screen. With every release, we continue to push towards ensuring that Flutter is fast, beautiful, productive and open for every platform we support. In Flutter 1.20, which is released today to our stable channel, Flutter has improvements for every one of these four pillars.
 
 我们对 Flutter 的愿景是提供一个可移植的工具包，让您无论在任何屏幕上都能随心所欲地绘制像素，打造出美好的体验。每次更新，我们都着力确保 Flutter 能够在所有支持的平台上运行流畅、界面美观、开发高效而且保持开放性。通过稳定版渠道发布的 Flutter 1.20 在上述四个方面都进展颇多。
 
-In the category of fast, we’ve got multiple performance improvements, from the lowest levels of the rendering engine and in the Dart language itself.
-
 首先是运行流畅，我们从最底层的渲染引擎到 Dart 语言本身都实现了多项性能改进。
-
-To enable you to build Flutter apps that are ever more beautiful, this release has several UI enhancements, including the long-awaited support for autofill, a new way to layer your widgets to support pan and zoom, new mouse cursor support, updates to old favorite Material widgets (such as the time and date pickers), and a whole new responsive license page for the About box in your desktop and mobile form-factor Flutter apps.
 
 为了让您构建出更美观的 Flutter 应用，此版本提供了多项界面改进，包括期待已久的自动填充支持、支持平移和缩放的新 widget 布局方式、新的鼠标光标支持、旧版本中人气 Material widget（如时间和日期选择器）的更新，以及为桌面和移动端 Flutter 应用中的关于（About）界面带来了全新的响应式许可（license）展示页面。
 
-To make sure that you continue to be more productive, we’ve got updates to the [Flutter extension for Visual Studio Code](https://dartcode.org/) that brings Dart DevTools directly into your IDE, automatically updating your import statements as you move your files around and a new set of metadata for building your own tools.
-
 为了进一步提高开发效率，我们更新了 [Visual Studio Code 的 Flutter 扩展](https://dartcode.org/)，将 Dart DevTools 直整合进 IDE，在您移动文件时会帮您自动更新导入语句，并提供了一组新的元数据用于构建您自己的工具。
-
-And it’s because of Flutter’s openness and amazing community contributors that this release includes 3,029 merged PRs and 5,485 closed issues from 359 contributors from around the world, including 270 contributors from the Flutter community at large. In fact, this marks the largest number of contributors we’ve ever had for a Flutter release. Special shoutout to community contributor [CareF](https://github.com/CareF) for 28 PRs, [AyushBherwani1998](https://github.com/AyushBherwani1998) for 26 PRs, including 10 to the Flutter samples as part of his Google Summer of Code project, and [a14n](https://github.com/a14n) for 13 PRs, many of which are in service of landing null safety for Flutter (more on that topic soon!). We couldn’t create Flutter without a broad team of community contributors, so thank you!
 
 得益于 Flutter 的开放性和来自社区的出色贡献，此版本包含了全球 359 名贡献者（其中包括来自 Flutter 社区的 270 名贡献者）的 3,029 个合并 PR，关闭了 5,485 个 issue。因此本次更新的 Flutter 版本也是目前为止拥有最多贡献者的版本。在这里特别感谢在社区中贡献了 28 个 PR的 [CareF](https://github.com/CareF)，贡献了 26 个 PR 的 [AyushBherwani1998](https://github.com/AyushBherwani1998)（包括他用于 Google Summer of Code 项目的 10 个 Flutter 示例），以及贡献了 13 个 PR 的 [a14n](https://github.com/a14n)（其中一大部分用于支持 Flutter 的空安全性，有关该主题的更多信息即将到来！）。Flutter 的诞生离不开社区贡献者们的广泛支持。谢谢大家！
 
-Each new release of Flutter brings with it increased usage and momentum. In fact, in April, [we reported](https://medium.com/flutter/flutter-spring-2020-update-f723d898d7af) that the number of Flutter apps in the Google Play store had reached 50,000, with a peak rate of 10,000 new apps/month. Now, just over three months later, there are more than 90,000 Flutter apps in Google Play. We’re seeing a lot of this growth in India, which is now the #1 region for Flutter developers, having doubled in the last six months, which aligns well with [Google’s increased investment](https://www.businessinsider.com/google-alphabet-india-health-agriculture-education-tech-ai-sundar-pichai-2020-7) in that region. And finally, Flutter isn’t Flutter without Dart, so it’s great to see the that [the IEEE has reported that Dart has moved up 4 slots since last year to be #12](https://spectrum.ieee.org/static/interactive-the-top-programming-languages-2020) in the top 50 languages that they track.
-
 Flutter 每一个新版本的发布都伴随着使用量的增长和更迅猛的发展态势。事实上，在 4 月份我们曾 [报道过](https://flutter.cn/posts/flutter-spring-2020-update) Google Play 商店中 Flutter 应用的数量已经达到 50,000，月度新增应用数量峰值更是高达 10,000。现在，短短三个月后，Google Play 中的 Flutter 应用数量已经超过 90,000。增长最快的当属印度，那里已经是 Flutter 开发者最多的地区，开发者数量在过去六个月中翻了一番，这与 [Google 在该地区增加的投资](https://www.businessinsider.com/google-alphabet-india-health-agriculture-education-tech-ai-sundar-pichai-2020-7) 密切相关。最后，如果没有 Dart 语言，Flutter 也不会成为现在的 Flutter。这里分享一个好消息：在 IEEE 的 [开发语言榜单](https://spectrum.ieee.org/static/interactive-the-top-programming-languages-2020) 中，Dart 相比去年上升了 4 位，在榜单的前 50 种语言中排名第 12。
-
-## Performance improvements for Flutter and Dart
 
 ## Flutter 和 Dart 的性能改进
 
-On the Flutter team, we’re always looking for new ways to decrease the size and latency of your app. As an example of the former, this release fixes [a tooling performance issue with icon font tree shaking](https://github.com/flutter/flutter/pull/55417) and [makes font tree shaking the default behavior](https://github.com/flutter/flutter/pull/56633) when building your non-web apps. Icon font tree shaking removes the icons that you’re not using in your app, thus reducing the size. Using this against the Flutter Gallery app, we found that it [reduced the app size by 100kb](https://github.com/flutter/flutter/pull/49737). Now you get this behavior by default in your mobile apps when you’re doing a release build. It’s currently restricted to TrueType Fonts, but that restriction will be lifted in future releases.
-
 Flutter 团队一直在寻找缩减应用大小和延迟的新方法。对于大小，[此版本修复了在进行图标字体摇树（tree-shaking）操作时的工具性能问题](https://github.com/flutter/flutter/pull/55417)，并在您构建非 web 应用时默认进行 [字体摇树操作](https://github.com/flutter/flutter/pull/56633)。图标字体摇树操作会移除应用中未使用的图标，从而缩减其大小。在对 Flutter Gallery 应用进行该操作后，我们发现 [应用大小缩减了 100kb](https://github.com/flutter/flutter/pull/49737)。现在，在构建移动版应用的发布版本时该操作会默认执行。目前仅限于 TrueType 字体，但在未来版本中将取消这个限制。
-
-Another performance improvement we’ve made in this release reduces jank in the initial display of your animation using a warm-up phase. You can see an example of the jank improvement in this animation (slowed down to half speed).
 
 此版本带来的另一项性能改进是使用预热阶段减少动画初始显示时的卡顿。以下为卡顿改进的动画示例（半速播放）。
 
 ![](https://devrel.andfun.cn/devrel/posts/2020/08/455f666234c9d.gif){:max-width="90%"}
 
-animation without and with the SkSL warm-up
-
 △ 使用和不使用 SkSL 预热的动画
-
-If a Flutter app has janky animations during the first run, the Skia Shading Language shader provides for pre-compilation as part of your app’s build that can speed it up by more than 2x. If you’d like to take advantage of this advanced functionality, see [the SkSL warm-up page](https://flutter.dev/docs/perf/rendering/shader) on flutter.dev.
 
 如果 Flutter 应用在首次运行时的动画出现卡顿，那么 Skia Shading Language 着色器将在应用构建中提供预编译，将速度提高 2 倍以上。如果您想使用此高级功能，请参见 flutter 文档中的 [SkSL 预热页面](https://flutter.cn/docs/perf/rendering/shader)。
 
-And finally, as we optimize for desktop form-factors, we continue to refine our mouse support. In this release, we’ve [refactored the mouse hit testing system](https://github.com/flutter/flutter/pull/59883) to provide a number of architectural advantages that were blocked due to performance issues. The refactoring enables us to improve the performance by as much as 15x in our web-based microbenchmarks! What this means to you is that you get better, more consistent, and more accurate hit testing w/o giving up performance: win-win!
-
 最后，在针对桌面环境的优化中，我们进一步完善了对鼠标的支持。在此版本，我们 [重构了鼠标点击测试系统](https://github.com/flutter/flutter/pull/59883)，带来了许多曾因性能问题受阻的架构优势。在基于 web 的微型基准测试中，重构使性能提高了多达 15 倍！这意味着，您可以在保证性能的前提下，获得更好、更一致、更准确的点击测试结果：实现双赢！
-
-With this better, faster, stronger mouse hit testing, we’ve added support for mouse cursors — one of the most upvoted features for desktop. Several commonly used widgets will display the cursors you expect by default, or you can specify another from the list of supported cursors.
 
 有了更好、更快、更强大的鼠标点击测试，我们又增加了鼠标光标支持，这也是桌面端最受期待的功能之一。一些常用的 widget 将默认显示主流光标，您也可以从支持的光标列表中指定其他光标。
 
 ![](https://devrel.andfun.cn/devrel/posts/2020/08/86c0af8ecf3d3.gif){:max-width="90%"}
 
-new mouse cursors over existing widgets on Android
-
 △ 鼠标在 Android 既有的 widget 上悬停时切换显示光标
-
-This release of Flutter is built on the 2.9 release of Dart. This features a new state-based, two-pass UTF-8 decoder with decoding primitives optimized in the Dart VM, partially taking advantage of SIMD instructions. UTF-8 is by far the most widely used character encoding method on the internet, and being able to decode it quickly is critical when receiving large network responses. In our UTF-8 decoding benchmarks we have seen improvements across the board from nearly 200% for English texts to 400% for Chinese texts on low-end ARM devices.
 
 此版本 Flutter 基于 2.9 版 Dart 构建，采用基于状态的全新双通 UTF-8 解码器，解码原语在 Dart VM 中优化，部分利用了 SIMD 指令。UTF-8 是目前互联网上最常用的字符编码方法。在接收大型网络响应时，快速对其进行解码至关重要。在 UTF-8 解码基准测试中，我们在低端 ARM 设备上测得的性能得到了全面改进：英语文本提升至近 200%，中文文本提升至 400%。
 
-## Autofill for mobile text fields
-
 ## 移动端文本字段自动填充
-
-One of the #1 most requested Flutter features for a while has been to support the underlying Android and iOS support for text autofill in Flutter programs. With [PR 52126](https://github.com/flutter/flutter/pull/52126), we’re pleased to say that the wait is over — no more asking your users to re-enter data that the OS has already gathered for them.
 
 一段时间以来，呼声最高的 Flutter 功能之一就是为 Flutter 应用中的文本自动填充提供 Android 和 iOS 的底层支持。通过 [PR 52126](https://github.com/flutter/flutter/pull/52126)，我们很高兴地宣布该支持已经实现，如果操作系统已经搜集到可供自动填充的信息，您的用户无需再重新输入了。
 
 ![](https://devrel.andfun.cn/devrel/posts/2020/08/04693616a125a.gif){:max-width="90%"}
 
-Autofill in action
-
 △ 自动填充
-
-You’ll be pleased to hear that we’ve already started adding this functionality for the web, as well.
 
 再告诉您一个好消息，我们已经开始着手在 web 端实现这一功能。
 
-## A new widget for common patterns of interaction
-
 ## 用于常见交互模式的全新 widget
-
-This release introduces a new widget, the InteractiveViewer. The InteractiveViewer is designed for building common kinds of interactivity into your app, like pan, zoom, and drag ’n’ drop, even in the face of resizing, which [this simple Go board sample](https://github.com/justinmc/flutter-go) demonstrates.
 
 此版本引入了一个新的 widget：InteractiveViewer。InteractiveViewer 旨在为您的应用构建常见交互，如平移、缩放和拖放，甚至在可调节大小的窗口中也可实现这些交互，请参见下面这个 [简单的围棋示例](https://github.com/justinmc/flutter-go)。
 
 ![](https://devrel.andfun.cn/devrel/posts/2020/08/1926f95f7fd40.gif){:max-width="90%"}
 
-Zooming, panning, resizing, dragging and dropping with the InteractiveViewer
-
 △　InteractiveViewer 的缩放、平移、调整大小与拖放
 
-To see how to integrate the InteractiveViewer into your own app, [check out the API documentation](https://api.flutter.dev/flutter/widgets/InteractiveViewer-class.html) where you can play with it in DartPad. Also, if you’d like to hear about how the InteractiveViewer was designed and developed, you can [see a presentation by the author for Chicago Flutter on YouTube](https://www.youtube.com/watch?v=ChFa0A72Uto).
-
 请查看 [API 文档](https://api.flutter.cn/flutter/widgets/InteractiveViewer-class.html)，了解如何将 InteractiveViewer 集成到您自己的应用中，您也可以在 DartPad 中快速进行体验。另外，如果您想了解 InteractiveViewer 的设计和开发经历，可以观看 ChicagoFlutter 发布的[演讲视频](https://www.youtube.com/watch?v=ChFa0A72Uto)。
-
-If you’re interested in adding the kind of interactivity to your Flutter app that InteractiveViewer enables, then you’ll probably also be happy to hear that we’ve [added more capabilities to drag ’n’ drop](https://github.com/monkeyswarm/DragTargetDetailsExample) in this release. Specifically, if you’d like to know precisely where the drop happened on the target widget (it’s always been available to the Draggable object itself), now you can get that information with the DragTarget onAcceptDetails method.
 
 有兴趣在 Flutter 应用中加入更多类似 InteractiveViewer 的交互？欢迎了解一下我们在这一版本 [对拖放功能所做的增强](https://github.com/monkeyswarm/DragTargetDetailsExample)。具体来说，如果您想知道拖拽的“放置”操作发生在目标 widget（始终对 Draggable 对象可用）上的精确位置，现在您可以通过 DragTarget 的 onAcceptDetails 方法获得该信息。
 
 ![](https://devrel.andfun.cn/devrel/posts/2020/08/89b6c425a5767.gif){:max-width="90%"}
 
-New drag target accept details in action
-
 △ 接收拖放目标详情信息演示
-
-Check out [this sample](https://github.com/monkeyswarm/DragTargetDetailsExample) for the details and look forward to a future release that will make this information available during the drag as well so that the DragTarget can more easily provide visual updates during a drag operation.
 
 您可以通过这个 [示例](https://github.com/monkeyswarm/DragTargetDetailsExample)了解详细信息，未来版本还将在拖动过程中提供这些信息，以便 DragTarget 在拖动操作期间更轻松地提供可视化的更新。
 
-## Updated Material Slider, RangeSlider, TimePicker, and DatePicker
-
 ## Material Slider / RangeSlider / TimePicker / DatePicker Widget 更新：
-
-In addition to new widgets, this release includes a number of updated widgets to match [the latest Material guidelines](https://material-io.cn/components/sliders). These include Slider and RangeSlider. For more information, see [What’s new with the Slider widget?](https://medium.com/flutter/whats-new-with-the-slider-widget-ce48a22611a3)
 
 除了新添加的 widget，此版本还包含许多既有 widget 的更新，以匹配 [最新的 Material 指南](https://material-io.cn/components/sliders)。其中包括 Slider 和 RangeSlider。更多信息参见 [Slider widget 的更新](https://medium.com/flutter/whats-new-with-the-slider-widget-ce48a22611a3)。
 
 ![](https://devrel.andfun.cn/devrel/posts/2020/08/163a04b7ec35d.png){:max-width="90%"}
 
-updated Material Slider
-
 △ 新版 Material Slider
 
 ![](https://devrel.andfun.cn/devrel/posts/2020/08/4b39c88d13982.png){:max-width="95%"}
 
-Updated Material RangeSlider
-
 △ 新版 Material RangeSlider
-
-DatePicker has been updated to include a new compact design as well as support for date ranges.
 
 更新的 DatePicker 新添了紧凑型设计以及对日期范围的支持。
 
 ![](https://devrel.andfun.cn/devrel/posts/2020/08/9b72841cf6b9a.gif){:max-width="90%"}
 
-Updated DatePicker
-
 △ 新版 DatePicker
-
-And finally, TimePicker has a completely new style.
 
 最后，TimePicker 也有了全新的视觉风格。
 
 ![](https://devrel.andfun.cn/devrel/posts/2020/08/aa761b870a116.png){:max-width="90%"}
 
-updated TimePicker
-
 △ 新版 TimePicker
-
-If you’d like to play around with it, here’s [a fun web demo built with Flutter](https://flutter-time-picker.firebaseapp.com/#/).
 
 如果您想上手操作，请试试 [使用 Flutter 构建的趣味网络演示](https://flutter-time-picker.firebaseapp.com/#/)。
 
-## Responsive Licenses page
-
 ## 响应式许可页面
-
-Another update this release is the new responsive licenses page available from the AboutDialog.
 
 此版本的另一个更新是 AboutDialog 中提供的新的响应式许可页面。
 
 ![](https://devrel.andfun.cn/devrel/posts/2020/08/f46d9adbfbdba.png){:max-width="90%"}
 
-new licenses page
-
 △ 新的许可页面
-
-[PR 57588](https://github.com/flutter/flutter/pull/57588), from community contributor [TonicArtos](https://github.com/TonicArtos), is not only updated to match Material guidelines, making it just plain nice to look at, but it’s easier to navigate and designed to work as well on tablets and desktops as on phones. Thanks, TonicArtos! Since every Flutter app should be showing the licenses for the packages they’re using, you just made every Flutter app better!
 
 社区贡献者 [TonicArtos](https://github.com/TonicArtos) 的 [PR 57588](https://github.com/flutter/flutter/pull/57588) 遵循 Material 指南进行更新，外观更加精美，更易于导航，并且在平板电脑、桌面设备和手机上都一样好用。谢谢 TonicArtos！由于每个 Flutter 应用都应显示其所用 package 的许可，如此一来每个 Flutter 应用都获得了改进！
 
-## New pubspec.yaml format required for publishing plugins
-
 ## 发布插件所需的新 pubspec.yaml 格式
 
-Of course, Flutter isn’t just the widgets; it’s also the tooling and this release comes with too many updates to mention. However, here are some of the highlights.
-
 当然，Flutter 不仅是 widget (在 Flutter 里: Everything is a Widget)，它也是一个工具。今天这个版本中带来的更新实在太多，无法一一提及。下面是一些亮点：
-
-First and foremost, a public service announcement: if you’re a Flutter plugin author, then the legacy pubspec.yaml format is no longer supported for publishing plugins. If you try, you’ll get the following error message when executing pub publish:
 
 首先是一则声明：如果您是 Flutter 插件作者，发布插件时将不再支持使用旧的 pubspec.yaml 格式。在使用旧格式文件执行 pub publish 时会收到以下错误消息：
 
 ![](https://devrel.andfun.cn/devrel/posts/2020/08/439e46e8de177.png){:max-width="90%"}
 
-Legacy pubspec format error message upon plugin publication
-
 △ 插件发布时使用旧 pubspec 格式后收到的错误消息
-
-The old format did not support specifying which platforms your plugins support, and has been deprecated since Flutter 1.12. [The new pubspec.yaml format](https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin-platforms) is now required for publishing new or updated plugins.
 
 旧格式不能指定插件支持的平台，自 Flutter 1.12 起已弃用。现在，发布新的插件或更新插件时需要使用 [新的 pubspec.yaml 格式](https://flutter.cn/docs/development/packages-and-plugins/developing-packages#plugin-platforms)。
 
-For clients of plugins, the tools still understand the old pubspec format and will for the foreseeable future. All existing plugins on pub.dev using the legacy pubspec.yaml format will continue to work with Flutter apps for the foreseeable future.
-
 对于插件的用户，开发工具在当下和可预见的将来仍然能理解旧 pubspec 格式。在可预见的将来，pub.dev 上所有使用旧 pubspec.yaml 格式的既有插件可继续在 Flutter 应用中使用。
 
-## Preview of embedded Dart DevTools in Visual Studio Code
-
 ## 功能预览：在 Visual Studio Code 中嵌入 Dart DevTools
-
-The biggest tooling update in this release comes to the Visual Studio Code extension, which provides a preview of a new feature to enable you to bring Dart DevTools screens directly into your coding workspace.
 
 此版本最大的工具更新是 Visual Studio Code 扩展，它提供了一项新功能的预览，使您能够将 Dart DevTools 界面直接嵌入编程工作区。
 
 ![](https://devrel.andfun.cn/devrel/posts/2020/08/1bb7686b6aee2.png){:max-width="90%"}
 
-Preview of Layout Explorer from Dart DevTools embedded into Visual Studio Code
-
 △ 预览功能：在 Visual Studio Code 中嵌入 Dart DevTools 的 Layout Explorer
-
-Enable this feature with the new `dart.previewEmbeddedDevTools` setting. The above screenshot shows the Flutter Widget Inspector embedded directly into Visual Studio Code but with this new setting enabled, you can choose your favorite page embed using the Dart DevTools menu on the status bar.
 
 使用新的 `dart.previewEmbeddedDevTools` 设置启用此功能。在上面的屏幕截图中，Flutter Widget Inspector 直接嵌入 Visual Studio Code，但是启用新设置后，您可以使用状态栏上的 Dart DevTools 菜单嵌入其他您偏好的页面。
 
 ![](https://devrel.andfun.cn/devrel/posts/2020/08/e483d4839aed8.png){:max-width="90%"}
 
-This menu allows you to choose which pages to show.
-
 通过此菜单选择要显示的页面。
 
 ![](https://devrel.andfun.cn/devrel/posts/2020/08/3a9be4183f989.gif){:max-width="90%"}
 
-This feature is still in preview, so [let us know if you have any trouble with it](https://github.com/Dart-Code/Dart-Code/issues).
-
 该功能仍处于预览状态，如果您遇到任何问题，请 [在这里提交反馈](https://github.com/Dart-Code/Dart-Code/issues)。
 
-## Updates to network tracking
-
 ## 网络监测功能更新
-
-The latest version of Dart DevTools comes with an updated version of the Network page that enables web socket profiling.
 
 最新版本 Dart DevTools 带有更新的 Network 页面，可以实现网络套接字分析。
 
 ![](https://devrel.andfun.cn/devrel/posts/2020/08/f2570ba7c41dd.png){:max-width="90%"}
 
-Timing, status and content type of socket connections on the Network page of Dart DevTools
-
 △ Dart DevTools 的 Network 页面上的套接字连接时间、状态和内容类型
-
-The Network page now adds timing information to the network calls from your app, along with other information like status and content type. Additional improvements have been made to the details UI to provide an overview of the data in a websocket or http request. We’ve also got more plans for this page to include HTTP request/response bodies and monitoring gRPC traffic.
 
 现在，Network 页面添加了应用进行网络调用的时间、状态和内容类型等信息。详细信息界面也有额外改进，以提供 websocket 或 http 请求中数据的概览。我们还为这个页面制定了更多计划，包括加入 HTTP 请求/响应正文和 gRPC 流量监测。
 
-## Updating import statements on file rename
-
 ## 在文件重命名时更新导入语句
-
-Another new feature for Visual Studio Code is updating imports on rename, which automatically updates import statements when files are moved or renamed.
 
 Visual Studio Code 的另一个新功能是当文件被移动或重命名时自动更新导入语句。
 
 ![](https://devrel.andfun.cn/devrel/posts/2020/08/3a9be4183f989.gif){:max-width="90%"}
 
-moving Dart files in Visual Studio Code updates the import statements
-
 △ 在 Visual Studio Code 中移动 Dart 文件会更新导入语句
-
-This feature currently only works for single files and not multiple files or folders, but that support is coming soon.
 
 该功能目前仅适用于单个文件，暂不支持多个文件或文件夹（即将到来！）。
 
-## Tooling metadata for every tool builder
-
 ## 面向每个工具制造者的工具元数据
-
-One more update to mention is for people building Flutter tooling. We’ve created a new project on GitHub to capture and publish metadata about the Flutter framework itself. It provides machine-readable data files for the following:
 
 还有一项为 Flutter 工具开发者提供的更新。我们在 GitHub 上创建了一个新项目，来捕获和发布有关 Flutter 框架本身的元数据。它提供以下机器可读数据文件：
 
-* a [catalog](https://github.com/flutter/tools_metadata/blob/master/resources/catalog/widgets.json) of all of the current Flutter widgets (395 widgets!)
-
-  当前所有 Flutter widget 的 [目录](https://github.com/flutter/tools_metadata/blob/master/resources/catalog/widgets.json)（有 395 个！）
-
-* a [mapping of Flutter framework color names to color values](https://github.com/flutter/tools_metadata/tree/master/resources/colors), for both the Material and Cupertino color sets
-
-  Flutter 框架中 [颜色名称到颜色值的映射](https://github.com/flutter/tools_metadata/tree/master/resources/colors)，支持 Material 和 Cupertino 颜色集
-
-* [Icon metadata](https://github.com/flutter/tools_metadata/tree/master/resources/icons) for Material and Cupertino icons, including icon names and preview icons
-
-  Material 和 Cupertino 图标的 [图标元数据](https://github.com/flutter/tools_metadata/tree/master/resources/icons)，包括图标名称和预览图标
-
-
-This is the same metadata that we use for the Android Studio / IntelliJ and VS Code extensions ourselves; we thought you might find it useful when building your own tools. In fact, this metadata enables the feature in the IntelliJ family of IDEs to show the color being used in your Flutter code:
+* 当前所有 Flutter widget 的 [目录](https://github.com/flutter/tools_metadata/blob/master/resources/catalog/widgets.json)（有 395 个！）
+* Flutter 框架中 [颜色名称到颜色值的映射](https://github.com/flutter/tools_metadata/tree/master/resources/colors)，支持 Material 和 Cupertino 颜色集
+* Material 和 Cupertino 图标的 [图标元数据](https://github.com/flutter/tools_metadata/tree/master/resources/icons)，包括图标名称和预览图标
 
 这与我们在 Android Studio / IntelliJ 和 VS Code 扩展中的元数据相同；我们认为这对您构建自己的工具会有所帮助。实际上，此元数据使 IntelliJ 系列 IDE 的功能可以显示 Flutter 代码中使用的颜色：
 
 ![](https://devrel.andfun.cn/devrel/posts/2020/08/ca7d24a599cd8.png){:max-width="90%"}
 
-Related to that is a new feature in IntelliJ and Android Studio that displays color blocks for Color.fromARGB() and Color.fromRGBO():
-
 与此相关的是 IntelliJ 和 Android Studio 中的一项新功能，该功能可为 Color.fromARGB() 和 Color.fromRGBO() 显示色块：
 
 ![](https://devrel.andfun.cn/devrel/posts/2020/08/5c8d5b3dcd271.png){:max-width="90%"}
 
-Special thanks to [dratushnyy](https://github.com/dratushnyy) on GitHub for contributing improvements to the color previews in IntelliJ!
-
 特别感谢 [dratushnyy](https://github.com/dratushnyy) 在 GitHub 上为 IntelliJ 中的颜色预览做出的贡献！
 
-## Typesafe platform channels for platform interop
-
 ## 平台互操作的类型安全平台通道
-
-In response to popular demand from plugin authors in our user surveys, recently we’ve been experimenting on how to make communication between Flutter and the host platform safer and easier for [plugins](https://flutter.dev/docs/development/packages-and-plugins/developing-packages) and [Add-to-App](https://flutter.dev/docs/development/add-to-app). To address this need, we created [Pigeon](https://pub.dev/packages/pigeon), a command-line tool that uses Dart syntax to generate type-safe messaging code on top of platform channels without adding additional runtime dependencies. With Pigeon, instead of manually matching method strings on platform channels and serializing arguments, you can invoke Java/Objective-C/Kotlin/Swift class methods and pass non-primitive data objects by directly calling Dart methods (and vice versa).
 
 为了回应插件作者在用户调研中的普遍需求，最近，我们一直以 [插件](https://flutter.cn/docs/development/packages-and-plugins/developing-packages) 和 [Add-to-App](https://flutter.cn/docs/development/add-to-app) （部分使用了 Flutter 的应用）为对象，探求如何才能让 Flutter 与宿主平台之间的通信更安全、更轻松。为了满足这一需求，我们创建了命令行工具 [Pigeon](https://pub.flutter-io.cn/packages/pigeon)，使用 Dart 语法在平台通道上生成类型安全的消息代码，无需添加其他运行时依赖项。您无需在平台通道上手动匹配方法字符串和序列化参数，就可以调用 Java/Objective-C/Kotlin/Swift 类方法，并通过直接调用 Dart 方法传递非原始类型数据对象（反之亦然）。
 
 ![](https://devrel.andfun.cn/devrel/posts/2020/08/607007baf455d.png){:max-width="90%"}
 
-While still in prerelease, Pigeon has become mature enough that we’re using it ourselves in the [video_player](https://pub.dev/packages/video_player) plugin. If you’d interested in testing out Pigeon for your own uses, see the updated the [platform channel documentation](https://flutter.dev/docs/development/platform-integration/platform-channels#pigeon) as well as this [sample project](https://github.com/flutter/samples/tree/master/add_to_app/flutter_module_books).
-
 Pigeon 虽然处于预发布阶段，但已经足够成熟，我们已经将其用于 [video_player](https://pub.flutter-io.cn/packages/video_player) 插件。如果您有兴趣测试 Pigeon 供自己使用，请参见更新的 [平台通道文档](https://flutter.cn/docs/development/platform-integration/platform-channels#pigeon) 以及此 [示例项目](https://github.com/flutter/samples/tree/master/add_to_app/flutter_module_books)。
-
-## Too many tooling updates to list
 
 ## 还有众多工具更新，不胜枚举
 
-So much great stuff has happened to the tools in the Flutter 1.20 timeframe that we can’t list it all here. However, you might want to take a look at the update announcements themselves:
-
 截至 Flutter 1.20 发布，众多工具的版本也全新亮相，我们无法在此列出所有内容，请查看它们的更新公告：
 
-* [VS Code extensions v3.13](https://groups.google.com/g/flutter-announce/c/TlN12RemsYw)
-
-  [VS Code 扩展 v3.13](https://groups.google.com/g/flutter-announce/c/TlN12RemsYw)
-
-* [VS Code extensions v3.12](https://groups.google.com/g/flutter-announce/c/8tSufvaRJUg)
-
-  [VS Code 扩展 v3.12](https://groups.google.com/g/flutter-announce/c/8tSufvaRJUg)
-
-* [VS Code extensions v3.11](https://groups.google.com/g/flutter-announce/c/gM0bqO7NFA0)
-
-  [VS Code 扩展 v3.11](https://groups.google.com/g/flutter-announce/c/gM0bqO7NFA0)
-
-* [Flutter IntelliJ Plugin M46 Release](https://groups.google.com/g/flutter-announce/c/8C2v2ueXjts)
-
-  [Flutter IntelliJ 插件 M46 版](https://groups.google.com/g/flutter-announce/c/8C2v2ueXjts)
-
-* [Flutter IntelliJ Plugin M47 Release](https://groups.google.com/g/flutter-announce/c/6SF3PG_XB8g/m/6mAY7eC_AAAJ)
-
-  [Flutter IntelliJ 插件 M47 版](https://groups.google.com/g/flutter-announce/c/6SF3PG_XB8g/m/6mAY7eC_AAAJ)
-
-* [Flutter IntelliJ Plugin M48 Release](https://groups.google.com/g/flutter-announce/c/i9NTk5o9rZQ)
-
-  [Flutter IntelliJ 插件 M48 版](https://groups.google.com/g/flutter-announce/c/i9NTk5o9rZQ)
-
-* [New tools for Flutter developers, built in Flutter](https://medium.com/flutter/new-tools-for-flutter-developers-built-in-flutter-a122cb4eec86)
-
-  [我们用 Flutter 写了一套全新的 Flutter 开发者工具](https://mp.weixin.qq.com/s/4mcFo3z8DhCDkEMX7IPmww)
-
-
-## Breaking Changes
+* [VS Code 扩展 v3.13](https://groups.google.com/g/flutter-announce/c/TlN12RemsYw)
+* [VS Code 扩展 v3.12](https://groups.google.com/g/flutter-announce/c/8tSufvaRJUg)
+* [VS Code 扩展 v3.11](https://groups.google.com/g/flutter-announce/c/gM0bqO7NFA0)
+* [Flutter IntelliJ 插件 M46 版](https://groups.google.com/g/flutter-announce/c/8C2v2ueXjts)
+* [Flutter IntelliJ 插件 M47 版](https://groups.google.com/g/flutter-announce/c/6SF3PG_XB8g/m/6mAY7eC_AAAJ)
+* [Flutter IntelliJ 插件 M48 版](https://groups.google.com/g/flutter-announce/c/i9NTk5o9rZQ)
+* [我们用 Flutter 写了一套全新的 Flutter 开发者工具](https://mp.weixin.qq.com/s/4mcFo3z8DhCDkEMX7IPmww)
 
 ## 重要改动 (Breaking Changes)
 
-As ever, we try to keep the number of breaking changes low. Here’s the list from the Flutter 1.20 release.
-
 与往常一样，我们尽力将重要改动（breaking changes）的数量维持在较低水平。以下是 Flutter 1.20 版本中的重要改动列表。
 
-* [55336](https://github.com/flutter/flutter/pull/55336) Adding tabSemanticsLabel to CupertinoLocalizations — [Migration guide PR](https://github.com/flutter/website/pull/3996)
-
-  [55336](https://github.com/flutter/flutter/pull/55336)：将 tabSemanticsLabel 添加到 CupertinoLocalizations - 迁移 [指南 PR](https://flutter.cn/docs/release/breaking-changes/cupertino-tab-bar-localizations)
-
-* [55977](https://github.com/flutter/flutter/pull/55977) [Add clipBehavior to widgets with clipRect](https://flutter.dev/go/clip-behavior)
-
-  [55977](https://github.com/flutter/flutter/pull/55977)：[将 clipBehavior 添加至具有 clipRect 的 widget](https://files.flutter-io.cn/sources/flutter-design-docs/Clip_Behavior.docx)
-
-* [55998](https://github.com/flutter/flutter/pull/55998) [Fixes the navigator pages update crashes when there is still route wa…](https://groups.google.com/forum/#!searchin/flutter-announce/55998%7Csort:date/flutter-announce/yoq2VGi94q8/8pTsRL28AQAJ)
-
-  [55998](https://github.com/flutter/flutter/pull/55998)：[为 Navigator 的 TransitionDelegate 新加入了 isWaitingForExitingDecision 判断。](https://groups.google.com/forum/#!searchin/flutter-announce/55998%7Csort:date/flutter-announce/yoq2VGi94q8/8pTsRL28AQAJ)	
- 
-* [56582](https://github.com/flutter/flutter/pull/56582) [Update Tab semantics in Cupertino to be the same as Material](https://flutter.dev/docs/release/breaking-changes/cupertino-tab-bar-localizations#migration-guide)
-
-  [56582](https://github.com/flutter/flutter/pull/56582)：[更新 Cupertino 中的 Tab 语义，使其与 Material 相同](https://flutter.cn/docs/release/breaking-changes/cupertino-tab-bar-localizations#migration-guide)
-
-* [57065](https://github.com/flutter/flutter/pull/57065) Remove deprecated child parameter for NestedScrollView’s overlap managing slivers
-
-  [57065](https://github.com/flutter/flutter/pull/57065)：移除 NestedScrollView 重叠管理条中被弃用的子参数	
-
-* [58392](https://github.com/flutter/flutter/pull/58392) iOS mid-drag activity indicator
-
-  [58392](https://github.com/flutter/flutter/pull/58392)：确保在 iOS 里的系统行为一致性，为 CupertinoActivityIndicator 加入 progress 参数
-
-
-## Summary
+* [55336](https://github.com/flutter/flutter/pull/55336)：将 tabSemanticsLabel 添加到 CupertinoLocalizations - 迁移 [指南 PR](https://flutter.cn/docs/release/breaking-changes/cupertino-tab-bar-localizations)
+* [55977](https://github.com/flutter/flutter/pull/55977)：[将 clipBehavior 添加至具有 clipRect 的 widget](https://files.flutter-io.cn/sources/flutter-design-docs/Clip_Behavior.docx)
+* [55998](https://github.com/flutter/flutter/pull/55998)：[为 Navigator 的 TransitionDelegate 新加入了 isWaitingForExitingDecision 判断。](https://groups.google.com/forum/#!searchin/flutter-announce/55998%7Csort:date/flutter-announce/yoq2VGi94q8/8pTsRL28AQAJ)	
+* [56582](https://github.com/flutter/flutter/pull/56582)：[更新 Cupertino 中的 Tab 语义，使其与 Material 相同](https://flutter.cn/docs/release/breaking-changes/cupertino-tab-bar-localizations#migration-guide)
+* [57065](https://github.com/flutter/flutter/pull/57065)：移除 NestedScrollView 重叠管理条中被弃用的子参数	
+* [58392](https://github.com/flutter/flutter/pull/58392)：确保在 iOS 里的系统行为一致性，为 CupertinoActivityIndicator 加入 progress 参数
 
 ## 总结
 
-Hopefully, you’re as excited about this release as we are. From many angles, this is Flutter’s biggest release yet. With performance improvements, new and updated widgets, and tooling improvements, we can only hit the highlights. We want to thank you, the strong and growing set of community contributors that enables every Flutter release to be bigger, faster, and stronger than the one before. And there’s more to come, with support for [null safety](http://dart.dev/null-safety), a new version of the Ads, Maps, and WebView plugins, and more tooling support in the works. (In fact, you might be interested in Bob Nystrom’s deep dive on [Understanding null safety](https://dart.dev/null-safety/understanding-null-safety).)
-
 希望您和我们一样喜爱这一版本。从很多角度来看，这都是 Flutter 迄今为止规模最大的版本发布。其中包含性能的显著提升、新增并更新了许多 widget，以及对工具做出的诸多改进，考虑到文章篇幅我们只能着重介绍部分亮点。我们要向大家致谢，感谢不断壮大的社区贡献者群体，让每一个 Flutter 版本都比先前功能更丰富、运行更流畅、性能更强大。敬请期待更多内容，包括 [空安全](http://dart.cn/null-safety)支持、新版本的 Ads、Maps 和 WebView 插件，以及正在构建的更多工具支持。（也欢迎大家阅读 Bob Nystrom 的文章以深入 [了解空安全](https://dart.cn/null-safety/understanding-null-safety)）
-
-With all of this extra power in Flutter and the tools, what are you going to build?
 
 Flutter 和工具已经全新升级，您会打造出怎样精彩的 Flutter 作品呢？

--- a/src/posts/announcing-flutter-1-7-9.md
+++ b/src/posts/announcing-flutter-1-7-9.md
@@ -5,153 +5,85 @@ toc: true
 
 文 / Tim Sneath，谷歌 Dart & Flutter 产品组产品经理
 
-Today we're pleased to announce the general availability of Flutter 1.7, a smaller release after the major feature announcements at Google I/O. Flutter 1.7 contains support for AndroidX and for updated Play Store requirements, a number of new and enhanced components, and bug fixes to customer-reported issues.
-
 今天，我们非常高兴地向大家宣布又一个正式版本的发布 —— Flutter 1.7，这是继上次 I/O 时众多重要功能发布以来的一次小更新。Flutter 1.7 包含了对 AndroidX 的支持，满足了 Play 商店近期对应用提出的要求，包含了一些新的和增强过的组件，修复了开发者们提出的 bug 等。
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot7-release/announcing-1-7.png){:width="95%"}
 
-If you already have Flutter on your system and you're on the default stable channel, you can upgrade to version 1.7 by running `flutter upgrade` from the command line. The updated release is also included in [a new installation](https://flutter.dev/docs/get-started/install) of Flutter.
-
 如果你已经安装，并使用默认稳定构建渠道 (stable channel) 的 Flutter，要升级到 1.7 版本，只需要运行 `flutter upgrade` 即可。同时，你可以在 [这个文档里](/docs/get-started/install) 查看如何新安装 Flutter。
-
-## AndroidX Support for New Apps
 
 ## 支持 AndroidX
 
-[AndroidX](https://developer.android.com/jetpack/androidx) is a new open source support library from the Jetpack team that helps Android apps stay updated with the latest components without sacrificing backward compatibility. Now that AndroidX is itself stable and many Flutter packages have been updated to support it, Flutter now supports [creating new Flutter projects with AndroidX](https://github.com/flutter/flutter/pull/31028), which reduces the work needed to integrate with other parts of the Android ecosystem.
-
 [AndroidX](https://developer.android.google.cn/jetpack/androidx)  是 Android 团队用于在 Jetpack 中开发、测试、打包和发布库以及对其进行版本控制的开源项目，帮助 Android 应用通过最新的组件保持更新而无需牺牲向后兼容性。目前 AndroidX 已经稳定，很多 Flutter packages 已经更新和支持它，Flutter 现在可以支持 [创建一个 AndroidX 项目 (new Flutter project with AndroidX)](https://github.com/flutter/flutter/pull/31028) 了，这也减少了与 Android 生态系统集成所你需要做的工作。
-
-When creating a Flutter project, you can add the `--androidx` flag to ensure the generated project targets the new support library. More information about migrating existing projects to AndroidX can be found [on flutter.dev](https://flutter.dev/docs/development/packages-and-plugins/androidx-compatibility#for-plugin-maintainers-migrating-a-flutter-plugin-to-androidx). We're actively working on bringing AndroidX / Jetifier support for apps with mixed AndroidX / Android Support libraries, such as in add-to-app cases, and will have more to share on this front in a forthcoming post.
 
 当创建 Flutter 项目的时候，你可以通过添加 `--androidx`  来确保生成的项目文件支持 AndroidX，更多关于将项目迁移到 AndroidX 的相关信息，请访问 [官方文档](/docs/development/androidx-migration#for-plugin-maintainers-migrating-a-flutter-plugin-to-androidx) 上的说明。我们也在积极努力为使用了 AndroidX 和 Android 混合库的应用带去 AndroidX 或 Jetifier 的支持，也会将其作为 add-to-app 的中的一项来支持，接下来的文章中会为大家带来更多相关的内容。
 
-## Support for Android app bundles and 64-bit Android apps
-
 ## 支持 Android App Bundles 和 64 位的 Android 应用
-
-From August 1st, 2019, Android apps that use native code and target Android 9 Pie will be [required to provide a 64-bit version](https://developer.android.google.cn/distribute/best-practices/develop/64-bit) in addition to the 32-bit version when publishing to the Google Play Store. While Flutter has long supported generating 64-bit Android apps, version 1.7 adds support for creating [Android App Bundles](https://developer.android.google.cn/guide/app-bundle) that target both 64-bit and 32-bit from a single submission. See the updated [documentation on publishing Flutter-based Android apps](https://flutter.dev/docs/deployment/android) to learn how to do this, as well as how to create separate APK files for both 32-bit and 64-bit devices.
 
 从 2019 年 8 月 1 日开始，为了 target 到 Android Pie 版本，开发者们在 Google Play 上发布的应用 [必须支持 64 位架构](https://developer.android.google.cn/distribute/best-practices/develop/64-bit)。Flutter 一直都支持生成 64 位的 Android 应用，在 1.7 版本里，我们加入了对 [Android App Bundles](https://developer.android.google.cn/guide/app-bundle) 的支持，开发者们可以在一次提交里同时 target 到 64 位和 32 位。可通过阅读 [这篇文档](/docs/deployment/android) 了解到如何分别生成 32 位和 64 位到应用等更多内容。
 
-## New widgets and framework enhancements
-
 ## 新一批的 widget 和框架的增强功能
 
-We want your apps to look great and feel natural, regardless of what platform you're targeting. Correspondingly, we continue to update and enhance the widgets available for both Android and iOS.
-
 我们希望你的应用在任何平台上都可以看起来平滑自然，我们会持续在平台相关的 widgets 上投入。
-
-This release features a new [RangeSlider](https://github.com/flutter/flutter/pull/31681) control that lets you select a range of values on a single slider (for example a minimum and maximum temperature value):
 
 如下所示了一个名为 [RangeSlider](https://github.com/flutter/flutter/pull/31681) 的 widget，帮助你在单个滑块儿上选择一组值：
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot7-release/rangeslider-widget.gif){:width="95%"}
 
-The new, themeable RangeSlider widget supports continuous or discrete styles
-
 RangeSlider widget 支持连续或者分散的效果
-
-The [updated ](https://github.com/flutter/flutter/pull/31275)`[SnackBar](https://github.com/flutter/flutter/pull/31275)`[ widget](https://github.com/flutter/flutter/pull/31275) supports an updated look in the Material spec, and a [number](https://github.com/flutter/flutter/pull/31294) [of](https://github.com/flutter/flutter/pull/32177) [new](https://github.com/flutter/flutter/pull/31929) [samples](https://github.com/flutter/flutter/pull/32703) are added [to the](https://github.com/flutter/flutter/pull/34679) [documentation](https://github.com/flutter/flutter/pull/32530).
 
 [更新之后](https://github.com/flutter/flutter/pull/31275) 的 [SnackBar](https://github.com/flutter/flutter/pull/31275) 支持了最新的 Material 规范，文档里增加了许多 [样例代码](https://github.com/flutter/flutter/pull/34679) 。
 
-For [Cupertino](https://flutter.dev/docs/development/ui/widgets/cupertino), the Flutter library for building pixel-perfect iOS applications, we've made a number of updates. In particular, we've improved the fidelity of the `[CupertinoPicker](https://github.com/flutter/flutter/pull/31464)`[ and ](https://github.com/flutter/flutter/pull/31464)`[CupertinoDateTimePicker](https://github.com/flutter/flutter/pull/31464)`[ widgets](https://github.com/flutter/flutter/pull/31464), and added support for localization to non-English languages.
-
 [Cupertino](/docs/development/ui/widgets/cupertino) 是用来构建精美的 iOS 体验的 widgets 库，我们对其进行了大量的更新。特别提出的是，我们提高了 [CupertinoPicker](https://github.com/flutter/flutter/pull/31464) 和  [CupertinoDateTimePicker](https://github.com/flutter/flutter/pull/31464) widget 的保真度，并增加了对非英语语言本地化的支持。
 
-We also made major improvements to the [text selection and editing experience on iOS](https://flutter.dev/docs/resources/platform-adaptations#text-editing), regardless of whether you're using the Material or Cupertino design language. Also, a [new sample](https://github.com/flutter/samples/tree/master/platform_design) demonstrates how to make more significant platform adaptations across iOS and Android while retaining the same codebase.
-
 我们提升了 iOS 上的 [文本选择和编辑体验](/docs/resources/platform-adaptations#text-editing)。此外，我们新增了一个 [示例](https://github.com/flutter/samples/tree/master/platform_design)，关于如何使用同一份代码库，调整不同平台的操作体验和适配。
-
-Text rendering gets a big upgrade with support for rich [typography features](https://api.flutter.dev/flutter/painting/TextStyle/fontFeatures.html), including tabular and old-style numbers, slashed zeros, and stylistic sets, as [this demo](https://github.com/timsneath/typography) shows:
 
 文本渲染有了很大的提升，支持了丰富的 [排版样式](https://api.flutter.dev/flutter/painting/TextStyle/fontFeatures.html)：包括数字表格式对齐、旧式风格数字 (tabular and old-style numbers)、斜线零 (slashed zeros)、样式集 (stylistic sets)，如这个示例应用截图所示：
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot7-release/openType-font.png){:width="95%"}
 
-With Flutter, you can now add sophisticated typography with OpenType font feature support
-
 有了 OpenType 的字体支持，你可以用 Flutter 进行复杂的文字排版了
-
-Lastly, we've added support for [game controllers](https://github.com/flutter/flutter/pull/33868). Could this lead to some fun Flutter apps? You tell us!
 
 最后，我们加入了对 [游戏控制器](https://github.com/flutter/flutter/pull/33868) 的支持，会有更好玩的应用出现吗？
 
-## Focus on the Fundamentals
-
 ## 初心不忘
-
-Flutter 1.7 represents a lot of hard work by the team to respond to customer-reported issues, with [over 1,250 issues closed in the two months](https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aclosed+closed%3A2019-04-22..2019-06-21+sort%3Areactions-%2B1-desc) since our last stable release.
 
 整个团队付出很多努力推出了 Flutter 1.7 正式版，我们解决了开发者们在 GitHub 上提出的 [1250 多个问题](https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aclosed+closed%3A2019-04-22..2019-06-21+sort%3Areactions-%2B1-desc) 。
 
-With the rapid growth in Flutter, we're seeing lots of new issues reported, and to be transparent, the bug process that worked well when our project was smaller is not working so well now. As a result, our open issue count has increased significantly over the last few months, despite our progress in closing triaged issues. We're working to increase staffing in this area, which will help with faster triaging of new bugs, closing and merging duplicate issues and redirecting support requests to [StackOverflow](https://stackoverflow.com/questions/tagged/flutter).
-
 随着 Flutter 的快速增长，我们看到大家向我们报告了很多新的问题。为了保证项目过程的透明，我们一直在通过 GitHub 运行着这一套错误报告系统，但一些相对较小的项目，目前这个流程工作的并不是非常顺利。虽然我们在不想关 issue 关闭上有一些新的进展，但是过去几个月我们的 issue 还是增长的非常明显。我们也在努力增加这方面的资源配置，可以帮助我们更快的区分 bug，关闭及合并相同的 issue，以及将一些提问引导到 [StackOverflow](https://stackoverflow.com/questions/tagged/flutter)。
-
-In recent surveys, many of you said that you'd like to see us continue to invest in documentation and error messages. One key part of that work is to provide better structure for our errors which tools like VSCode and Android Studio can take advantage of in the future. You can see examples of this work [in issue 34684](https://github.com/flutter/flutter/pull/34684).
 
 在近期的开发者调查里，很多开发者希望我们在文档和错误信息方面有更持续的投入。一个关键部分是能够在 VSCode 和 Android Studio 里更结构化的输出错误信息，我们已经在着手 [这方面的工作](https://github.com/flutter/flutter/pull/34684)。
 
-We also fixed the top crashing bug, which was an error when the Flutter tool is unable to write to the Flutter directory. Flutter now fails gracefully if the user doesn't have write permissions, with clearer indications on how to fix the problem.
-
 我们也修复了崩溃率最高的 bug，Flutter 工具的写权限问题。Flutter 现在可以更优雅的处理写权限导致的崩溃问题，会又一个明晰的指示关于如何解决。
-
-In terms of documentation, we have an ever increasing list of samples that can be created directly from the flutter create tool. From the command line, you can run a command such as:
 
 文档方面，我们会持续增加示例代码。与此同时，你也可以通过 Flutter create 命令直接创建示例文档，如下是命令：
 
 ```flutter create --sample=widgets.Form.1 mysample```
 
-If a sample can be created in this way, you'll see a "Sample in the App" tab in the documentation, as in [this example for the Form widget](https://api.flutter.dev/flutter/widgets/Form-class.html):
-
 如果通过这种方式创建示例，你将在文档中的 Sample in the App 这一栏看到：
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot7-release/sample-at-docs.png){:width="95%"}
 
-We're also continuing to embed the popular [Widget of the Week](https://www.youtube.com/playlist?list=PLjxrf2q8roU23XGwz3Km7sQZFTdB996iG) videos directly into the documentation, as an easy way to grok the various widgets in Flutter's toolkit.
-
 我们也会持续把每周 Flutter widgets 视频嵌入到文档中，在开发者们浏览各种 widget 的时候可以得到更全面的理解。
-
-Behind the scenes, you'll see lots of underlying work to create infrastructure towards enabling Flutter on macOS and Windows, with further support for important concepts like right-click and unique platform infrastructure such as [MSBuild](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild?view=vs-2019). Support for non-mobile platforms is not yet available in the stable channel, however.
 
 还有一些幕后的设施建设工作正在进行，以便 Flutter app 更好的在 macOS 和 Windows 平台运行。比如支持一些较为重要的平台操作，比如右键和一些特别的平台基建工作（比如 [MSBuild](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild?view=vs-2019) 等）。不过，这些非移动平台的支持目前还没有在稳定构建渠道 (stable channel) 发布。
 
-Lastly, when you're building Flutter apps on the Mac, we now have support for [the new Xcode build system](https://github.com/flutter/flutter/pull/33684). This is on by default for new projects, and [easy to enable for existing projects](https://github.com/flutter/flutter/issues/20685#issuecomment-509731873).
-
 最后，当你在苹果电脑上开发 Flutter 应用的时候，我们支持了 [新的 Xcode 构建系统](https://github.com/flutter/flutter/pull/33684)，这个对新的应用是默认开启的，也同时方便 [支持现有的应用](https://github.com/flutter/flutter/issues/20685#issuecomment-509731873)。
-
-## An ever-growing Flutter community
 
 ## 不断壮大的 Flutter 社区
 
-As ever, it's exciting to see Flutter continue to grow in popularity and usage, and we also celebrate the ways customers large and small are using Flutter. Since I/O, the team has been busy with various events around the world: from [GMTC](https://gmtc2019.geekbang.org/) in China to meetups and presentations in New York and Mexico; it's been great to meet with many of you and hear about some of the apps that you're building.
-
 一如既往，我们非常高兴看到 Flutter 在受众群体和应用场景上继续持续增长，同时我们也欣赏各种不同的 Flutter 使用方式。自 I/O 以来，Flutter 团队致力于全球范围内的各项活动：从中国的 [GMTC](https://gmtc2019.geekbang.org/) 到纽约和墨西哥的交流会和演讲等，面对面对大家交流 Flutter 应用开发是一件特别棒的事情。
 
-We've talked about [Reflectly](https://www.forbes.com/sites/heatherfarmbrough/2018/05/01/reflectly-wants-to-be-an-adidas-of-the-mind/#572291294204) before: a small Danish company who built a beautiful mindfulness app for iOS and Android. Their app was just featured as Apple's App of the Day on their US iPhone app store, demonstrating how Flutter apps are more than capable of delivering reference-quality experiences:
 
-之前我们提到过[Reflectly](https://www.forbes.com/sites/heatherfarmbrough/2018/05/01/reflectly-wants-to-be-an-adidas-of-the-mind/#572291294204)，它是一个丹麦的公司，他们在 iOS 和 Android 平台开发了非常有吸引力的应用程序。他们的应用程序被美国 iPhone 应用商店评为当日最佳应用。这也证明了 Flutter 的真正潜力远远超过实现体验流畅的应用（同时可以帮助开发者获得成功）。
+之前我们提到过 [Reflectly](https://www.forbes.com/sites/heatherfarmbrough/2018/05/01/reflectly-wants-to-be-an-adidas-of-the-mind/#572291294204)，它是一个丹麦的公司，他们在 iOS 和 Android 平台开发了非常有吸引力的应用程序。他们的应用程序被美国 iPhone 应用商店评为当日最佳应用。这也证明了 Flutter 的真正潜力远远超过实现体验流畅的应用（同时可以帮助开发者获得成功）。
 
 <iframe src="//player.bilibili.com/player.html?aid=56686514&cid=99031924&page=1" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="560" height="315"> </iframe>
 
-And at the [WeAreDevelopers](https://events.wearedevelopers.com/) conference in Berlin, [BMW announced their new Flutter-based app](https://youtu.be/80pRyn7fZRk?t=1234), currently in development. Here's what Guy Duncan, CTO Connected Company at BMW, had to say:
-
 在柏林的  [WeAreDevelopers](https://events.wearedevelopers.com/) 大会中，[BMW 发布了他们基于 Flutter 的应用](https://youtu.be/80pRyn7fZRk?t=1234)，目前已经在开发中。下面这段描述来自 Guy Duncan，他是 BMW 集团互联公司的 CTO：
 
-> "By combining Dart and Flutter we have the first true cross-platform mobile toolkit; we feel it is a game changer to ensure feature parity for digital touchpoints and IoT.
-> 
->通过结合 Dart 和 Flutter，我们实现了第一个真正跨平台的移动工具包；我们认为它打破了原有的游戏规则，可以平衡数字交互和物联网的功能特性。
-
-> By moving forward with world class tooling, automation and modern functional programming patterns we can improve feature cycle time, security, and cost of delivery of features for the business."
->
+> 通过结合 Dart 和 Flutter，我们实现了第一个真正跨平台的移动工具包；我们认为它打破了原有的游戏规则，可以平衡数字交互和物联网的功能特性。
 > 通过使用主流的工具链、自动化工具和现代化的编程模式，我们可以优化循环时延、安全性、商业应用特性的推送成本。
 
-Beyond apps, of course the open source community is what makes Flutter such a fun place to work, with so many [resources](https://flutterx.com/), [plugins](https://pub.dev/flutter), [events](https://flutterevents.com/) and [meetups](https://www.meetup.com/topics/flutter/). We continue to be amazed by how you're using Flutter and are honored to be able to share the fun with you all!
-
-除了应用程序，整个开源社区所涉及的众多 [资源](https://flutterx.com/)，[插件](https://pub.dev/flutter)， [Flutter 社区活动](https://flutterevents.com/) 和 [Meetup](https://www.meetup.com/topics/flutter/) 也使得 Flutter 变得格外生机勃勃。
+除了应用程序，整个开源社区所涉及的众多 [资源](https://flutterx.com/)，[插件](https://pub.flutter-io.cn/flutter)， [Flutter 社区活动](https://flutterevents.com/) 和 [Meetup](https://www.meetup.com/topics/flutter/) 也使得 Flutter 变得格外生机勃勃。
 我们会持续关注大家基于 Flutter 所实现的各种有趣的应用，同时也非常荣幸和大家一起分享其中的乐趣。
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot7-release/flutter-bag.jpeg){:width="95%"}

--- a/src/posts/flutter-development-on-a-pixelbook.md
+++ b/src/posts/flutter-development-on-a-pixelbook.md
@@ -1,8 +1,7 @@
 ---
-title: Flutter Development on a Pixelbook
 title: 在 Pixelbook 上开发 Flutter 应用
-description: Newly added features in Chrome OS that let you develop and test a Flutter application without a simulator or emulator.
 description: Chrome OS 的新特性能够让您无需模拟器就能开发并测试 Flutter 应用程序。
+toc: true
 ---
 
 文 / Tim Sneath，谷歌 Dart & Flutter 产品组产品经理
@@ -11,71 +10,41 @@ description: Chrome OS 的新特性能够让您无需模拟器就能开发并测
 
 原文：[ProAndroidDev Medium 专栏](https://proandroiddev.com/flutter-development-on-a-pixelbook-dde984a3fc1e)
 
-> Note: this article was updated in January 2019 to match newer ChromeOS builds. But as Google continues to work on making this easier, it’s possible that you’ll see minor changes from what is shown here. Please leave a note or a comment if you see anything that’s unclear or broken in the latest builds, and I’ll fix it.
->
 > 提示：本文已在 2019 年 1 月更新以匹配较新版本的 ChromeOS。然而，随着 Google 在持续不断对其优化，你可能会看到一些部分与本文描述内容有微小的差异。如果你在本文的最新版本中看到任何不清楚或错误的内容，请留下备注或评论，我会修正它。
-
-In a somewhat underrated talk at Google I/O 2018, [Emilie Roberts](https://medium.com/@emilieroberts) announced some cool new Chrome OS features that make [a Pixelbook to do Android development](https://developer.android.google.cn/topic/arc/studio). With the new [Linux on Chromebooks](https://blog.google/products/chromebooks/linux-on-chromebooks/) feature, you can now [run Android Studio directly on a Pixelbook](https://developer.android.google.cn/topic/arc/studio), [debug over a wi-fi connection to an Android device](https://developer.android.google.cn/studio/command-line/adb#wireless) or even run the resultant Android app locally on the Pixelbook. This is all thanks to the [Crostini](https://chromium.googlesource.com/chromiumos/docs/+/master/containers_and_vms.md) project, which provides a containerized Linux instance on the device.
 
 在 Google I/O 2018 演讲中，[Emilie Roberts](https://medium.com/@emilieroberts) 介绍了 Chrome OS 中一些很酷的新特性，主题是[在 Pixelbook 上进行 Android 开发](https://developer.android.google.cn/topic/arc/studio) 。借助 [Linux on Chromebooks](https://blog.google/products/chromebooks/linux-on-chromebooks/) 这一新功能，你现在可以[直接在 Pixelbook 上运行 Android Studio](https://developer.android.google.cn/topic/arc/studio)，并[通过 Wi-Fi 连接调试 Android 设备](https://developer.android.google.cn/studio/command-line/adb#wireless)，甚至可以在 Pixelbook 上直接运行生成的 Android 应用程序。这一切都得感谢  [Crostini](https://chromium.googlesource.com/chromiumos/docs/+/master/containers_and_vms.md) 计划，它为设备提供了一个 Linux 容器实例。
 
-What is even more cool is that all this works just as well with Flutter, which means you can do all your development on-device without even needing an emulator to test your app out. While a little experimental, it makes Pixelbook a fascinating device for any Flutter developer who isn’t bought into the Apple ecosystem.
-
 更酷的是这一切都能在 Flutter 上表现得同样出色。这意味着你可以直接在设备上进行所有开发，甚至不需要模拟器来测试你的应用程序。虽然这有一点实验性质，但它对于那些不需要加入苹果生态系统的 Flutter 开发者来说变得相当有吸引力。
-
-Here’s a screenshot of this working, taken directly from a Pixelbook running Visual Studio Code locally and connected through the [Android Device Bridge](https://developer.android.google.cn/studio/command-line/adb) to a Flutter app also running locally. This is not an emulator — the Flutter app is being executed directly on the Pixelbook (check out the target platform in the bottom-right corner of the Visual Studio Code status bar).
 
 下面的截图来自一台正在运行 Visual Studio Code 的 Pixelbook，而且通过 [Android Device Bridge](https://developer.android.google.cn/studio/command-line/adb) 连接的 Flutter 应用程序同样也运行在本地。这可不是什么模拟器——Flutter 应用能够在 Pixelbook 上直接运行（请看 Visual Studio代码状态栏右下角的目标平台）。
 
 ![Flutter running locally on a Pixelbook, connected with hot reload to Visual Studio Code](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-development-on-a-pixelbook/flutter_dev_env_on_pixelbook.png){:width="85%"}
 
-In the rest of this article, I’m going to provide step-by-step instructions to get this running on your own device. Linux on Chromebook support is ‘beta-quality’ for now, and it requires one of [the supported devices for Crostini](https://chromium.googlesource.com/chromiumos/docs/+/master/containers_and_vms.md#Supported-Now), including [Pixelbook](https://chromium.googlesource.com/chromiumos/docs/+/master/containers_and_vms.md#Supported-Now). Your mileage may vary; things may break, and of course the performance characteristics of ChromeOS devices will be very different to those of a typical iPhone or Android device. And we’re not guaranteeing that every Flutter scenario will work at this stage. Enough caveats? :)
-
 接下来我将在这篇文章中分步说明如何在你自己的设备上运行它。Linux on Chromebook 支持现在已经进入 beta 阶段，但它需要[一台支持 Crostini 的设备](https://chromium.googlesource.com/chromiumos/docs/+/master/containers_and_vms.md#Supported-Now)，包括 [Pixelbook](https://store.google.com/product/google_pixelbook)。 但也可能会出现一些失灵的情况，这都因人而异。当然，ChromeOS 设备的性能特征将与典型的 iPhone 或 Android 设备的性能特征相差较大。我们也不能保证每个 Flutter 场景都能在这个平台上正确运行。这算是一个足够的警告了吧 ；）
-
-### Getting the basics installed
 
 ### 基础的环境安装
 
-For the full experience of debugging Flutter, you’ll currently need your device to be in [developer mode](http://www.chromium.org/chromium-os/chromiumos-design-docs/developer-mode), which removes some of the sandbox protections that would be available to a typical consumer and enables you to sideload untrusted applications that aren’t on the Play Store. On a Pixelbook, you can enter developer mode by holding down the `Esc` and `Refresh` keys while you press the power button. The system will reboot into the recovery screen (which prompts you to insert a USB stick). Ignore the text on the screen and hit Ctrl+D, which will initiate the process after a further warning.
-
 要获得 Flutter 完整的调试功能，目前你需要将你的设备设为[开发者模式](http://www.chromium.org/chromium-os/chromiumos-design-docs/developer-mode)，这样就可以移除一些为典型消费者使用的沙箱保护措施，并让你的设备支持不受 Play 商店信任的应用程序。在 Pixelbook 上，你可以在按下电源（Esc）按钮的同时按住 Refresh 键进入开发者模式。系统将重新启动并进入恢复页面（他会提示你插入U盘）。你只需要忽略这段文字并按住 Ctrl + D 即可，这将会在一段警告后进入该模式。
 
-Since this support is evolving, it’s not a bad idea to [switch your device to the beta channel](https://support.google.com/chromebook/answer/1086915?hl=en) for Chrome OS, which will give you the latest bits (at the time of writing in January 2019, this was 71.0.3578.94, but this changes regularly). Once you’ve changed the channel, you will need to let Chrome OS download and install the latest bits from that channel, and then reboot.
-
 由于这种支持正在不断发展，[将设备切换到 Chrome OS 的 beta 频道](https://support.google.com/chromebook/answer/1086915?hl=en) 并不是一个坏主意，它将会为你提供最新的信息（在 2019 年 1 月时它是 71.0.3578.94，但它会定期更新）。当你切换频道后，你需要让 Chrome OS 下载并安装该频道的最新版本，然后重启。
-
-Once you’ve rebooted with the latest channel bits, you’ll see a new entry in the Settings app that offers the chance to install Linux support on your Chromebook:
 
 当你使用最新的频道重启后，你会在"设置"中看到一个新的条目，该条目可以让你在 Chromebook 上安装 Linux 支持。
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-development-on-a-pixelbook/turn_on_linux_env_on_cb.png){:width="85%"}
 
-When you turn this on, ChromeOS will offer to download and activate the Linux container:
-
 在你打开开启它之后，ChromeOS 将会弹出下载并激活 Linux 容器的窗口。
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-development-on-a-pixelbook/turn_on_linux_env_on_cb_processing.png){:width="85%"}
 
-On my machine, this took a couple of minutes to complete; when finished, there was a shiny new Terminal app icon on the app launcher, which I promptly pinned to my taskbar.
-
 我的机器花费了几分钟的时间来完成它。完成后，你会看到应用程序启动器上有一个闪亮的新终端应用程序图标，我立即把它固定到任务栏。
-
-### Installing Flutter
 
 ### 安装 Flutter
 
-Now for the fun bits. Launch the terminal, and use apt to make sure you have the very latest Linux bits by running `sudo apt update && sudo apt upgrade`.
-
 现在该来讲点有趣的事了。打开终端，然后使用 apt 进行检查，确保你正在使用较新版本的 Linux。你可以运行 `sudo apt update && sudo apt upgrade` 这个命令来完成这项操作。
-
-Let’s also install some other utilities and dependencies you’ll need at various points during the next steps:
 
 我们还将在接下来的步骤中安装一些您需要的其他工具包和依赖项。
 
 `$ sudo apt install libglu1-mesa lib32stdc++6`
-
-Because you’re running in a container, the easiest way to download into the container instance in current builds is to just use `wget`. (You can download them using Chrome and [then transfer them through an SSH tunnel](https://developer.android.google.cn/topic/arc/studio#mount_linux_files), but that’s a little more laborious.) It’s easier to download and install Flutter with the following commands:
 
 由于你正在运行一个容器，在当前版本中下载到容器实例的最简单方法是使用 `wget`（你也可以使用 Chrome 下载它们并通过 SSH 隧道发送它们，但那会更加复杂）。你能够通过以下命令很轻松地下载并安装 Flutter。
 
@@ -85,25 +54,15 @@ $ tar xf flutter_linux_v1.5.4-hotfix.2-stable.tar.xz
 $ export PATH=`pwd`/flutter/bin:$PATH
 ```
 
-Now you should be able to run `flutter doctor` and it should give you a clean bill of health for Flutter itself, even though it will complain about a lack of tooling or devices at this stage.
-
 现在你应该可以运行 `flutter doctor` 命令了，它会为 Flutter 提供一个干净的运行环境，即使它会在这个阶段抱怨缺乏必要的工具或设备。
-
-### Installing Visual Studio Code and Android Studio
 
 ### 安装 Visual Studio Code 和 Android Studio
 
-Now it’s time to install an IDE or two. Both of the primary supported IDEs for Flutter (Android Studio and Visual Studio Code) work perfectly well within the Chrome OS Linux support. Regardless of whether you plan to use Android Studio as your IDE, however, you’re going to want to install it so that you have the Android build tools.
-
 现在，是时候安装一两个 IDE 了。Flutter 主要支持的两个 IDE （Android Studio 和 Visual Studio Code）都在 Chrome OS Linux 支持版上运行得相当完美。但是，无论你是否计划将Android Studio 作为 IDE，你都需要安装它以便拥有 Android 的构建工具。
-
-[Android Studio can be downloaded directly](https://developer.android.google.cn/studio/) from the website, but because Linux runs in a separate container than the Chrome browser, you’ll have to manually move it before you can access it from your terminal. Hold down the Shift key while dragging to move it from the Downloads directory to the Linux files node (which represents the home `~` directory in the Linux container).
 
 你能够在官网上直接下载 [Android Studio](https://developer.android.google.cn/studio/)，但是由于 Linux 运行在与 Chrome 浏览器不同的容器中，所以你必须手动移动它才能在终端进行访问。拖住时同时按住 Shift 健，将其从 Download 目录移动到 Linux 文件节点中（它在 Linux 容器中代表了 home `~` 目录）。
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-development-on-a-pixelbook/download_android_sdk_to_linux_env.png){:width="85%"}
-
-Then you can run the following to extract and install Android Studio:
 
 然后，你就可以运行以下内容来解压缩并安装 Android Studio：
 
@@ -114,29 +73,19 @@ $ cd /usr/local/android-studio/bin
 $ ./studio.sh
 ```
 
-You’ll see a dialog like the following:
-
 你将会看到下面这样的弹窗：
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-development-on-a-pixelbook/start_page_as_on_cb.png)
 
-Click through the remaining setup steps (I didn’t bother selecting the Android Virtual Device, because, y’know, we don’t need it!). When the IDE launches, start a new blank project (accepting the defaults). We’re going to add a launch icon to make it easier to get back to Android Studio, so go to Tools / Create Desktop Entry.
-
 点击剩下的设置步骤（我没有为选择 Android 虚拟设备而烦恼，因为你知道的，我们不再需要它了！）。当 IDE 启动时，创建一个新的空白项目（使用默认设定即可）。为了更加轻松地返回 Android Studio，我们将添加一个启动图标，所以请转到 Tools / Create Desktop 项。
-
-Now we can install the Flutter plug-in for Android Studio, to add tools and integration for the IDE. Go to File / Settings, choose the Plugins node, and click Browse repositories… Search for the Flutter plugin, as shown below, and press the Install button.
 
 现在我们能够为 Android Studio 安装 Flutter 插件了。要安装这些工具和集成，请跳到 File / Settings 并选择 Plugin 节点，然后点击 **Browse repositories** 。在这里搜索 Flutter 插件，如下所示，然后点击 Install 按钮。
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-development-on-a-pixelbook/install_flutter_plugin_on_as.png){:width="85%"}
 
-One last step at this point — make sure you’ve accepted all the Android licenses by running the following:
-
 这部分的最后一步——通过运行以下命令以确保你已同意所有 Android 许可证：
 
 `$ flutter doctor --android-licenses`
-
-For Visual Studio Code, you can download and install with the following instructions, which download the Visual Studio Code package and install it with all needed dependencies (the `go.microsoft.com` URL automatically redirects to the latest version):
 
 对于 Visual Studio Code，你可以按照以下说明下载并安装。这将会下载 Visual Studio Code 包及必要的依赖并安装（go.microsoft.com URL会自动重定向到最新版本）。
 
@@ -145,27 +94,16 @@ $ curl -L -o vscode.deb https://go.microsoft.com/fwlink/?LinkID=760868
 $ sudo apt install ./vscode.deb
 ```
 
-Lastly, open Visual Studio Code and install the [Flutter extension](https://marketplace.visualstudio.com/items?itemName=Dart-Code.flutter).
-
 最后打开 Visual Studio Code 安装 [Flutter 扩展](https://marketplace.visualstudio.com/items?itemName=Dart-Code.flutter)。
-
-You’re mostly there! Running `flutter doctor -v` should now show that everything is set, except that there are no connected devices. We’ll fix that in the final step.
 
 你马上就要完成了！运行 `flutter doctor -v`，现在应该显示所有设置都已完成，除了 ` no connected devices` 这项，我们将会在最后解决这个问题。
 
-### Configuring the Pixelbook as a developer device
-
 ### 将 Pixelbook 配置为开发者设备
-
-We need to take care of a few things so that the Pixelbook is itself recognized by Android as a development device.
 
 我们需要处理一些事情，以便让 Pixelbook 被 Android 识别为开发设备。
 
-First up is to modify the Chrome OS firewall to [allow incoming ADB connections from the Linux side of the house](https://developer.android.google.cn/topic/arc/#configure-the-firewall). From a Chrome window, press Control+Alt+T to start the Chrome OS terminal and then type `shell` to start a shell within the terminal. If `shell` doesn’t work, then chances are you forgot to set your device into developer mode as described earlier.
 
-首先是修改 Chrome OS 的防火墙，以[允许来自 Linux 端传入 ADB 链接](https://developer.android.google.cn/topic/arc/#configure-the-firewall)。在一个 Chrome 窗口中点击 Control+Alt+T 来开启 Chrome OS 的终端，然后输入 `shell` 来启动一个终端中的 shell。如果 `shell` 不起作用，那么你可能是忘记了将设备设为开发者模式，我们前面提到过这一点。
-
-Now run a few `sudo` commands:
+首先是修改 Chrome OS 的防火墙，以 [允许来自 Linux 端传入 ADB 链接](https://developer.android.google.cn/topic/arc/#configure-the-firewall)。在一个 Chrome 窗口中点击 Control+Alt+T 来开启 Chrome OS 的终端，然后输入 `shell` 来启动一个终端中的 shell。如果 `shell` 不起作用，那么你可能是忘记了将设备设为开发者模式，我们前面提到过这一点。
 
 现在，运行一些 `sudo` 命令： 
 
@@ -175,47 +113,31 @@ chronos@localhost / $ sudo /usr/libexec/debugd/helpers/dev_features_rootfs_verif
 chronos@localhost / $ sudo reboot
 ```
 
-After the system reboots, you’ll need one last command:
-
 在系统重启后，你只需要运行这最后一个命令：
 
 ``` 
 chronos@localhost / $ sudo /usr/libexec/debugd/helpers/dev_features_ssh
 ```
 
-Next up is to turn on Android developer mode. You might think we’ve already done this right at the beginning, but we’ve only set the Pixelbook itself into developer mode: the Android side requires the same magic invocation that you may be used to from phones. The setting is a bit buried: from the Settings app, select the Google Play Store menu and then choose Manage Android preferences:
-
 接下来是打开 Android 开发者模式。你也许会想，我们最开始不是已经完成这一步了吗？但是我们仅仅是设置 Pixelbook 自身为开发者模式：安卓端需要使用你也许用过的手机上相同的魔术开关。这个设置隐藏的有点深：从设置应用中选择 Google Play Store 菜单，然后选择管理 Android 偏好设置（Manage Android preferences）：
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-development-on-a-pixelbook/manage_android_pref_on_cb.png){:width="85%"}
-
-This will launch a separate Settings app for the hosted Android environment, where you’ll find the About device page:
 
 这将会为 Android 托管环境打开另一个设置应用，你可以在其中找到"关于设备"（**About device**）页面。
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-development-on-a-pixelbook/android_env_on_cb_about_page.png)
 
-Tap the build number seven times: that’s the magic incantation that unlocks the Developer Options screen and will let you turn on ADB debugging:
-
 连续点击 build number 7 次：这是解锁开发者选项屏幕的神奇咒语，可让你打开 ADB 调试：
 
 ![](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-development-on-a-pixelbook/turn_on_dev_mode_android_on_cb.png){:width="85%"}
 
-Now you can at last set up an ADB connection to the local device that Flutter can reach. You’ll find adb in the following location, assuming you unzipped Android Studio from your home directory: $/Android/Sdk/platform-tools/adb
-
 现在，你终于可以建立 Flutter 能够访问的本地设备的 ADB 连接。假设你是在主目录下解压 Android Studio，那么你会在以下位置找到 `adb` ：`$/Android/Sdk/platform-tools/adb`
-
-Run the following command to connect to the local Android instance:
 
 执行以下命令，以连接到本地 Android 实例：
 
 `$ adb connect 100.115.92.2:5555`
 
-### Putting all the pieces together
-
 ### 汇总
-
-With luck, `flutter doctor` should give you a clean bill of health. You can now create and run a Flutter app, for instance:
 
 幸运的话，`flutter doctor` 会给你一个干净健康的环境。你现在可以创建并运行 Flutter 应用了！例如：
 
@@ -225,24 +147,14 @@ $ cd testapp
 $ flutter run
 ```
 
-and after Gradle has built the APK and deployed it you should see a fullscreen window pop up with the sample app running.
-
 等 Gradle 编译完 APK 并将其安装后，你将会看到一个全屏的正在运行样例应用代码的窗口跳出来。
 
 ![A simple Flutter app running in full-screen mode on a Pixelbook.](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-development-on-a-pixelbook/flutter_starter_app_on_cb.png){:width="85%"}
 
-Like any other Android app running on a Pixelbook, you can restore the window from maximized, at which point the app will look very similar to how it would look if running on a phone: except it’s running directly on your Pixelbook!
-
 与其他在 Pixelbook 上运行的 Android 应用程序一样，你可以从最大化的窗口恢复为正常大小，这时候应用程序将会看上去和手机上运行的外观非常相似：除了它是直接运行在你的 Pixelbook 上的！
-
-### Recommendations and Caveats
 
 ### 建议及注意事项
 
-You’ll probably want to adjust the screen DPI settings a little to get more real estate. Some apps respond better than others to this; in particular, I found that a couple of the Android Studio dialogs were way too small for the given DPI setting.
-
 您可能希望稍微调整屏幕 DPI 设置以获得更多空间。有些应用程序在这方面上比其他应用程序响应更好;特别是我发现一些 Android Studio 对话框对于给定的 DPI 设置来说太小了。
-
-However, in general, this seems very useful, particularly if you’re willing to live on the edge as the various teams finish building out these features. And if you’ve got a Pixelbook and have been waiting for a way to learn Flutter or try building apps, it’s well worth giving this a go! Have fun and let us know how you get on: you’ll find the team on Twitter at [@FlutterDev](https://twitter.com/flutterdev).
 
 然而总的来说，这似乎非常有用，特别是如果你愿意使用这些由各个团队完成的最新特性的话。如果你有 Pixelbook 并一直在等待一个学习 Flutter 或尝试构建应用的方法的话，它绝对值得你试一试！祝你玩得开心，欢迎告诉我们你的故事：你可以在 Twitter 上的 [@flutterio](https://twitter.com/flutterio) 中找到我们团队。

--- a/src/posts/flutter-news-from-gdd-china-flutter1.9.md
+++ b/src/posts/flutter-news-from-gdd-china-flutter1.9.md
@@ -6,43 +6,23 @@ toc: true
  
 ![Google Developer Days taking place in China](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot9-release/flutter1-9-gdd-keynote.jpg){:width="95%"}
 
-This week is a big one for [Flutter](http://flutter.dev)! Today, at [Google Developer Days](https://events.google.cn/intl/en/developerdays2019/), our flagship conference for Chinese developers, we used the keynote to **announce our latest stable release: Flutter 1.9**. This release is our biggest update yet with more than 1,500 PRs from more than 100 contributors. The new features and updates span a wide range, from support for macOS Catalina and iOS 13 to improved tooling support, as well as new Dart language features and new Material widgets.
-
-本周对 [Flutter](http://flutter.dev) 意义非凡。Google 面向中国开发者举办的重量级年度盛会——[中国 Google 开发者大会](https://events.google.cn/intl/en/developerdays2019/)于今日正式拉开帷幕。在主题演讲环节，Flutter 团队宣布推出最新稳定版: Flutter 1.9。这是 Flutter 迄今为止最大的一次版本更新，100 余位贡献者提交共计超过 1,500 份 pull request。Flutter 1.9 引入的新特性与更新涵盖范围广泛，包括 macOS Catalina 和 iOS 13 支持、工具支持优化、多项 Dart 语言新特性以及全新的 Material widget。
-
-At the keynote, we also announced a major milestone for Flutter’s web support, with the **successful integration of Flutter’s web support into the main Flutter repository**, allowing developers to write for mobile, desktop and web with the same codebase. And we showcased [Tencent](https://www.youtube.com/watch?v=DVGIBU109nI&feature=youtu.be), one of the largest worldwide internet brands, who are using Flutter in a growing number of their mobile apps.
+本周对 [Flutter](http://flutter.cn) 意义非凡。Google 面向中国开发者举办的重量级年度盛会——[中国 Google 开发者大会](https://events.google.cn/intl/en/developerdays2019/)于今日正式拉开帷幕。在主题演讲环节，Flutter 团队宣布推出最新稳定版: Flutter 1.9。这是 Flutter 迄今为止最大的一次版本更新，100 余位贡献者提交共计超过 1,500 份 pull request。Flutter 1.9 引入的新特性与更新涵盖范围广泛，包括 macOS Catalina 和 iOS 13 支持、工具支持优化、多项 Dart 语言新特性以及全新的 Material widget。
 
 团队还在会上宣布了另一个具有里程碑意义的重磅消息: **Flutter web 支持现已成功合并到 Flutter 的主 repo**，自此以后，开发者只需使用同一套基准代码，便可为移动平台、桌面端和网页端开发应用。此外，团队也分享了来自全球互联网公司 [腾讯](https://www.youtube.com/watch?v=DVGIBU109nI&feature=youtu.be) 的成功案例，让现场观众体验了一把 Flutter 的蓬勃活力，亲眼见证越来越多的应用正在通过 Flutter 缔造精彩。
 
-Let’s take a deeper look at this week’s news, starting with what’s new in Flutter 1.9.
-
 接下来，让我们一起回顾一下 Flutter 要闻。首先，给大家介绍一下 Flutter 1.9 带来了哪些重要的更新内容。
-
-## Supporting macOS Catalina and iOS 13
 
 ## macOS Catalina 和 iOS 13 支持
 
-As Apple prepares to release Catalina, the latest version of macOS, we’ve worked hard to make sure that Flutter is ready for you to upgrade. We’ve updated the end-to-end tooling experience to ensure it works well on Catalina and with Xcode 11. This includes adding support for the new Xcode build system, enabling 64-bit support throughout the toolchain, and simplifying platform dependencies.
-
 苹果将在近期内推出新版本的 macOS 操作系统 Catalina，为此，团队付出了巨大努力，以确保 Flutter 做好升级准备，顺利适配新平台。比如说，我们进一步优化了端到端的工具体验，保证 Flutter 工具能够与 Xcode 妥善协作，助力开发者面向 Catalina 开发出优质应用，具体优化项包括：为新的 Xcode 构建系统提供支持、全工具链启用 64 位支持、简化平台依赖项等。
-
-With iOS 13 on the way, we’ve also been working to ensure your Flutter apps look great on the latest iPhone release. Flutter 1.9 includes [an implementation of the iOS 13 draggable toolbar](https://github.com/flutter/flutter/pull/35829), with both long-press and drag-from-right, and supports [vibration feedback](https://github.com/flutter/flutter/pull/37724). Work on iOS dark mode is also well underway with a number of [pull requests already merged](https://github.com/flutter/flutter/issues/35541).
 
 此外，随着 iOS 13 即将面世，团队也在积极推进相关的支持工作，以确保您的 Flutter 应用在新款 iPhone 设备上保持美观的界面。Flutter 1.9 实现了 [iOS 13 的拖曳式工具栏功能](https://github.com/flutter/flutter/pull/35829)，允许长按与从右往左拖动两项操作，并且为 [触感反馈](https://github.com/flutter/flutter/pull/37724) 提供了支持。不少开发者已经提交了 [pull request](https://github.com/flutter/flutter/issues/35541)，希望 Flutter 支持 iOS 夜间模式，团队目前已开始着手解决这方面的需求，争取尽早推出解决方案。 
 
-Finally, in the latest development builds, you can now turn on [experimental support for Bitcode](https://github.com/flutter/flutter/wiki/Creating-an-iOS-Bitcode-enabled-app), which is Apple’s platform-independent intermediate representation of a compiled program. Submitting your app as Bitcode allows Apple to optimize your binary in the future without resubmission, and opens the door to Flutter potentially supporting platforms like watchOS and tvOS that require Bitcode for app submission.
-
 最后，最新版本的开发构建允许您启用 [Bitcode 实验性支持](https://github.com/flutter/flutter/wiki/Creating-an-iOS-Bitcode-enabled-app)。Bitcode 是苹果新添加的一个编译特性，开启 Bitcode 功能后，开发者只需在编译环节上传与平台无关的 Intermediate Representation (中间文件) 即可。以 Bitcode 的形式上传应用后，苹果可以在后期直接对二进制文件进行优化，免除了开发者二次上传的麻烦，与此同时，这也为 Flutter 开启了更多的使用场景，比如说为 watchOS 和 tvOS 等要求上传 Bitcode 文件的平台提供支持。
-
-## New Material widgets
 
 ## 全新的 Material widget
 
-The [Material](https://material.io/) components and features also get an upgrade in Flutter 1.9. Material is one of the world’s leading open-source design systems, providing a comprehensive, flexible set of building blocks for implementing interactive user experiences across many platforms.
-
-Flutter 1.9 也对 [Material](https://material.io/) 组件和特性进行了升级。作为一款全球顶尖的开源设计系统，Material 提供了丰富多彩、灵活易操作的视觉元素，助力开发者在多个平台实现高交互性的用户体验。
-
-In this release, we provide several new widgets including `ToggleButtons` (left) and `ColorFiltered` (right).
+Flutter 1.9 也对 [Material](https://material-io.cn/) 组件和特性进行了升级。作为一款全球顶尖的开源设计系统，Material 提供了丰富多彩、灵活易操作的视觉元素，助力开发者在多个平台实现高交互性的用户体验。
 
 在 Flutter 1.9 中，我们新添加了若干 widget, 其中包括 ToggleButtons 和 ColorFiltered。
 
@@ -50,77 +30,43 @@ In this release, we provide several new widgets including `ToggleButtons` (left)
 
 ![Flutter ColorFilter Demo](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot9-release/image2phone.gif){:width="45%"}
 
-The `ToggleButtons` widget bundles a row of `ToggleButton` widgets together, often composed of a set of `Icon` and `Text` widgets, to form a set of buttons with fully customizable look and behavior. Do you want single selection or multi-select? Do you want to require at least one selection or allow none? Do you want square or rounded edges, thick or thin borders, icons or text, etc? You can see some of these options above on the left and see how they’re implemented in [the ToggleButtons sample](https://github.com/csells/flutter_toggle_buttons).
-
 ToggleButtons widget 可将同一行的多个 ToggleButton widget 组合到一起，其中每个 widget 各自又由一组图标和文本 widget 构成。通过这种组合，开发者将得到一组外观与行为完全可自定义的按钮。它能为您的应用按钮实现更加多元化的设计——不论是单选还是多选，选择至少一个或是零个，尖角还是圆角、粗边或细边，图标或文本——ToggleButtons widget 全都可以满足。请查看 [ToggleButtons 示例](https://github.com/csells/flutter_toggle_buttons)，了解以上需求的具体实现。
-
-As shown in the image above on the right, the `ColorFiltered` widget allows you to recolor a tree of child widgets just like you can recolor an image using one of several different algorithms (some of which are shown in the example screenshot above). This has many uses, for example, handling color blindness accessibility issues for your users. To see this in action, check out [the ColorFiltered sample](https://github.com/csells/flutter_color_filter).
 
 正如上文右图所示，ColorFiltered widget 允许您更改子 widget 树的颜色，这与利用算法 (部分算法见上图样例) 给图片重新上色差不多。该 widget 能够帮您处理许多用例，例如: 向用户提供更好的色彩无障碍服务等等。请查看 [ColorFiltered 示例](https://github.com/csells/flutter_color_filter)，了解该 widget 的工作细节。
 
-## Worldwide language support
-
 ## 全球语言支持
-
-We’ve also added support for 24 new languages, from Afrikaans to Zulu.
 
 我们还新增了南非语 (Afrikaans)、祖鲁语 (Zulu) 等 24 种语言的支持。
 
 ![Table of languages supported](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot9-release/i18n.png){:width="95%"}
 
-## Dart 2.5 release
-
 ## Dart 2.5 发布
-
-The end-to-end developer experience depends not just on the features of Flutter but also on the underlying language itself. As part of the Flutter 1.9 release, we are also releasing [Dart 2.5](https://medium.com/dartlang/dart-2-5-release-328822024970). Dart 2.5 includes a pre-release of Foreign Function Interface (FFI) support, providing native extensions so Dart can call directly into code written in C. It also introduces machine learning-powered code completions for the IDE. You can learn about both of these and more in the [Dart 2.5 announcement](https://medium.com/dartlang/dart-2-5-release-328822024970).
 
 如要保障流畅的端到端 Flutter 开发体验，仅仅凭借强劲的特性是不够的，底层语言也至关重要。在 Flutter 1.9 发布之际，我们也推出了最新版本的 Dart 语言——[Dart 2.5](https://medium.com/dartlang/dart-2-5-release-328822024970)，内含预发布版本的 Dart: FFI ( 外部函数接口 )，它可用于实现 Dart 语言与 C 语言之间的互操作 (interop)，以及由机器学习驱动的 IDE/ 编辑器代码补全功能。更多技术细节，请阅读 [Dart 2.5 发布说明](https://medium.com/dartlang/dart-2-5-release-328822024970)（请关注微信公众号后续推文）。
 
-## Toolchain improvements
-
 ## 工具链优化
-
-With this release, new projects default to Swift instead of Objective-C and Kotlin instead of Java for iOS and Android projects respectively. Since many [packages](https://pub.dev) are written with Swift, making it the default language removes manual work for adding those packages to an app created with the default options. Swift 5 is ABI stable, and thanks to [app thinning work Apple has done in recent releases](https://developer.apple.com/documentation/xcode_release_notes/xcode_10_2_release_notes/swift_5_release_notes_for_xcode_10_2#3138038), the Swift dynamic libraries no longer need to be included in the distribution package for iOS 12.2 or greater, reducing the size of Swift applications compared to previous releases.
 
 从 Flutter 1.9 开始，iOS 新项目默认使用 Swift 语言，而非 Objective-C；Android 新项目则默认使用 Kotlin，而非 Java。由于许多 [Flutter package](https://pub.dev/) 使用 Swift 编写，因此，一旦将 Swift 设置为默认语言后，开发者便无需再为启用默认设置的应用手动添加包。Swift 5 实现了 ABI 稳定，而且 [苹果在近期几个系统版本中也为应用瘦身做了许多工作](https://developer.apple.com/documentation/xcode_release_notes/xcode_10_2_release_notes/swift_5_release_notes_for_xcode_10_2#3138038)，因此 12.2 或更高版本的 iOS 系统将不再包含用于 Swift 的动态链接库，从而大幅缩小了 Swift 应用的体积。 
 
-And as Kotlin is now the default language for new projects in Android Studio, it seems natural to make the language switch for Android also. These options are now the default for both the `flutter` CLI tool and the [IntelliJ/Android Studio](https://plugins.jetbrains.com/plugin/9212-flutter) and [VS Code](https://marketplace.visualstudio.com/items?itemName=Dart-Code.flutter) plugins for Flutter, but you can always switch back to Objective-C or Java if you prefer.
-
 考虑到 Android Studio 新项目现在已经默认采用 Kotlin 作为开发语言了，因此，很自然地，我们就想着再往前迈一步，把所有 Android 项目的默认语言统一为 Kotlin。flutter CLI 工具、[IntelliJ/Android Studio](https://plugins.jetbrains.com/plugin/9212-flutter) 和 [VS Code](https://marketplace.visualstudio.com/items?itemName=Dart-Code.flutter) 插件均默认启用这些选项，不过，如有需要，您可随时切换回之前的 Objective-C 或 Java 语言。
-
-Additionally, we’ve been working to improve Flutter’s error messages by making them more readable, more concise and more actionable.
 
 此外，我们也在一直改善 Flutter 应用中的错误信息质量。优化之后，信息的可读性、简洁性和可操作性均有明显提升。
 
 ![Flutter error message](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot9-release/fluttererrormessage.png){:width="95%"}
 
-The Flutter User Experience team has led the charge on this project; you can read the details in a separate [blog post](https://medium.com/@taodong/e098513cecf9) covering the work on structured error display. We’ve just started to apply these new patterns, and you can expect more error messages to take advantage of this work in coming releases.
-
 该项目由 Flutter 用户体验团队负责牵头，如果您想了解更多有关结构化错误显示的内容，请阅读 [更精准更简洁: Flutter 改进错误信息提示](https://medium.com/flutter/improving-flutters-error-messages-e098513cecf9)。我们才刚刚开始采用这些新格式，预计未来将有更多错误信息会以结构化的形式呈现。
-
-## Flutter on the web
 
 ## 在 web 平台运行 Flutter
 
-And finally, we are very happy to announce that [the flutter_web repository](https://github.com/flutter/flutter_web) is deprecated now that web support has been merged into [the main flutter repository](https://github.com/flutter/flutter)! What this means is that if you have the latest builds of Flutter from the master or dev channel, you can target the web with the latest experimental version of Flutter by running `flutter run -d chrome`.
-
 最后，我们很高兴地宣布，flutter_web 这个 [repo](https://github.com/flutter/flutter_web) 已经完成了自己的使命，现在所有的 web 支持已经合并到 flutter 的 [主 repo](https://github.com/flutter/flutter)！这意味着，如果您通过 master 或 dev 渠道安装最新版本的 Flutter 构建，您只需要运行 flutter run -d chrome 就可以使用最新的试验版本 Flutter 来开发 web 应用。
-
-When you create a project, Flutter now creates a web runner via a minimal `web/index.html` file that bootstraps your web-compiled Flutter code. With that file in place, you can use the Flutter CLI tool or the IDE plugins to edit and run Flutter apps on the web.
 
 在您创建项目时，Flutter 会通过一个最小的 web/index.html 文件来生成一个 web 运行引擎 (web runner)，其中 web/index.html 文件主要用于自举 (bootstrap) 基于 web 编译的 Flutter 代码，有了这文件后，您可使用 Flutter CLI 工具或 IDE 中的 Flutter 插件来编辑或运行针对 web 平台开发的 Flutter 应用。
 
 ![screenshot of VS Code with web support enabled for Flutter](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot9-release/vscode.png){:width="95%"}
 
-Above is a screenshot of VS Code with web support enabled for Flutter. Notice the `web/index.html` file, along with the dropdown list allowing you to choose Chrome as your target development device. Support for web output with Flutter is still at an early phase, but this release represents a major step forward towards enabling production support for web development with Flutter.
-
 上图为启用了 Flutter web 支持的 VS Code 界面截屏。请注意 web/index.html 文件和顶部的下拉列表允许您选择 Chrome 作为目标设备。尽管 Flutter 的 web 支持还不成熟，但是我们在 Flutter 1.9 中朝着正确的方向迈进了一大步。
 
-At the end of July, we [announced an early adopter program](https://medium.com/flutter/flutter-for-web-early-adopter-program-now-open-9f1fb146e4c4) designed to get a group of select Flutter applications deployed to production on the web over the next six to twelve months. We received over 1,000 submissions to the program. Unfortunately, we don’t have the capacity to support everyone who applied to join the program, but now web support is merged into the Flutter framework, we’re excited that everyone can now experiment with this capability.
-
 我们在今年 7 月底启动了一项 [早期体验计划](https://medium.com/flutter/flutter-for-web-early-adopter-program-now-open-9f1fb146e4c4)，其主要目的是加快 web 版 Flutter 应用的落地速度。获选开发者能得到必要协助，在接下来的 6 到 12 个月内在 web 环境中推出生产版本的 Flutter 应用。非常感谢大家的踊跃报名，我们收到了超过 1,000 份示例与申请，但由于名额有限，对无法参加的开发者，我们深表遗憾。不过，目前 web 支持已正式合并到 Flutter 框架中，因此，每一位开发者都有机会利用 Flutter web 支持构建出精美的应用。
-
-Some community experiments have already showcased Flutter’s web output:
 
 我们的开发者已经构建了许多实用的 web 工具，下面就简单介绍一下 Flutter Widget Livebook 和 Panache。
 
@@ -128,43 +74,25 @@ Some community experiments have already showcased Flutter’s web output:
 
 ![Panache](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot9-release/communityexperiment2.png){:width="45%"}
 
-[Flutter Widget Livebook](https://flutter-widget-livebook.blankapp.org/) (left) is built with Flutter for web and shows Flutter widgets running live in your browser. [Panache](https://rxlabz.github.io/panache_web/) (right) is a tool for creating themes for Flutter which you can then download and drop directly into your code.
-
 [Flutter Widget Livebook](https://flutter-widget-livebook.blankapp.org/) 是一个在网页上展示 widget 运行效果的网站，它使用 Flutter 开发，并直接运行在网页上。[Panache](https://rxlabz.github.io/panache_web/) 则是一款为 Flutter 创建主题的工具，您可以下载创建好的主题，然后将其直接添加到代码中。
-
-Please give this updated experimental support for Flutter on the web a try and [let us know if you have any feedback](https://github.com/flutter/flutter/issues).
 
 欢迎大家尝试更新后的实验性 web 支持，并向我们 [分享您的使用感受](https://github.com/flutter/flutter/issues)。
 
-## Community
-
 ## 社区
-
-We’re thrilled to see continuing fast growth and adoption of for Flutter. Here at Google, hundreds of developers are working on more than twenty projects using Flutter, including some that are released and many that are still in development. At GDD China this week, we highlighted how Tencent, one of the largest internet brands, is using Flutter pervasively for a wide variety of projects:
 
 Flutter 惊人的成长速度和采用率让我们倍感欣慰。在 Google 内部，有超过 20 个项目正在稳步推进中，凝集着数千位工程师的辛勤付出，其中有部分项目已成功落地，其余的则尚在开发阶段。在本周的 Google 开发者大会上，我们已经与大家分享了全球互联网巨头腾讯的成功经验，介绍了腾讯是如何把 Flutter 灵活地运用到越来越多的产品中，欢迎收看下方视频，了解更多。
 Bilibili 视频链接 https://www.bilibili.com/video/av67230699/
 
 <iframe src="//player.bilibili.com/player.html?aid=67230699&cid=116573649&page=1" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true"> </iframe>
 
-Switching gears to something just for fun, if you have Google Assistant on your phone or one of the Google Nest Hub devices, try saying “OK Google. [Talk to Flutter Widget Quiz](https://assistant.google.com/services/a/uid/000000f3a4034e91).” We loved seeing this community-powered quiz that tests your knowledge of Flutter.
-
 现在，让我们插个轻松的话题，邀请您参加一个有趣的小游戏。请找到您手边的 Google Assistant 设备，然后对它说 “OK Google. Talk to Flutter Widget Quiz.” (OK Google, [为我接通 Flutter Widget 问答挑战赛](https://assistant.google.com/services/a/uid/000000f3a4034e91))。十分感谢 Flutter 社区对这份小测试的倾情贡献，期待各位小伙伴的精彩表现:
 
-![Flutter Widget Quiz](https://4.bp.blogspot.com/-WnoX_nu_xLQ/XXZ7zNXYH8I/AAAAAAAAH1A/jB4iodXkUnQsHUbbOg1J97yVIoa3XLEoACLcBGAs/s1600/flutterwidgetquiz.png){:width="80%"}
-
-## Conclusion
+![Flutter Widget Quiz](https://devrel.andfun.cn/devrel/posts/2021/02/36cc2facf9626.png){:width="80%"}
 
 ## 结语
 
-We love the support we’ve received from the developer community, whether in the form of blogs and articles, published apps or issues and code contributions. For more details on upgrading to Flutter 1.9, including details on how to fix any breaking changes that you might experience as you migrate your code, check out the detailed [Flutter 1.9 release notes](https://github.com/flutter/flutter/wiki/Release-Notes-Flutter-1.9.1).
-
 十分感谢 Flutter 开发者社区一路以来对我们的支持。来自全球各地的贡献者们为 Flutter 1.9 的发布投入了巨大的热情与努力，通过博客、文章、应用发布、报错、代码贡献等多种渠道为我们提供帮助。如果您想了解 Flutter 1.9 的升级方法，学习如何修复迁移过程中可能出现的问题，请参阅 [Flutter 1.9.1 版本说明](https://github.com/flutter/flutter/wiki/Release-Notes-Flutter-1.9.1)。
 
-There’s a ton for you to try with this release, from trying out [the new dart:ffi or ML-based code completion features](https://medium.com/dartlang/dart-2-5-release-328822024970) to [experimenting with Flutter for web](https://flutter.dev/wehttps://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot9-release/flutterwidgetquiz.pngthub.com/csells/flutter_color_filter) widgets to testing yourself on [your Flutter widget knowledge](https://assistant.google.com/services/a/uid/000000f3a4034e91).
-
 Flutter 1.9 提供了超级丰富的新功能等您前来体验，比如，新的 [dart:ffi](https://medium.com/dartlang/announcing-dart-2-5-super-charged-development-328822024970) 或者 [基于机器学习的代码补全功能](https://flutter.dev/web)，通过自己爱用且顺手的开发工具探索在 web 平台运行 Flutter、Catalina 与 iOS 13 支持、两款新出的 widget ([ToggleButtons](https://github.com/csells/flutter_toggle_buttons) 和 [ColorFiltered](https://github.com/csells/flutter_color_filter))，以及趣味满满的 [Flutter Widget 知识问答挑战赛](https://assistant.google.com/services/a/uid/000000f3a4034e91)。
-
-Now that you’ve got Flutter 1.9 in your hands, we’re excited to see what you will build with it!
 
 Flutter 1.9 已至，您将构建怎样的精彩？

--- a/src/posts/flutter-news-from-gdd-china-flutter1.9.md
+++ b/src/posts/flutter-news-from-gdd-china-flutter1.9.md
@@ -6,7 +6,7 @@ toc: true
  
 ![Google Developer Days taking place in China](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot9-release/flutter1-9-gdd-keynote.jpg){:width="95%"}
 
-本周对 [Flutter](http://flutter.cn) 意义非凡。Google 面向中国开发者举办的重量级年度盛会——[中国 Google 开发者大会](https://events.google.cn/intl/en/developerdays2019/)于今日正式拉开帷幕。在主题演讲环节，Flutter 团队宣布推出最新稳定版: Flutter 1.9。这是 Flutter 迄今为止最大的一次版本更新，100 余位贡献者提交共计超过 1,500 份 pull request。Flutter 1.9 引入的新特性与更新涵盖范围广泛，包括 macOS Catalina 和 iOS 13 支持、工具支持优化、多项 Dart 语言新特性以及全新的 Material widget。
+本周对 [Flutter](http://flutter.cn) 意义非凡。Google 面向中国开发者举办的重量级年度盛会——[中国 Google 开发者大会](https://events.google.cn/intl/en/developerdays2019/) 于今日正式拉开帷幕。在主题演讲环节，Flutter 团队宣布推出最新稳定版: Flutter 1.9。这是 Flutter 迄今为止最大的一次版本更新，100 余位贡献者提交共计超过 1,500 份 pull request。Flutter 1.9 引入的新特性与更新涵盖范围广泛，包括 macOS Catalina 和 iOS 13 支持、工具支持优化、多项 Dart 语言新特性以及全新的 Material widget。
 
 团队还在会上宣布了另一个具有里程碑意义的重磅消息: **Flutter web 支持现已成功合并到 Flutter 的主 repo**，自此以后，开发者只需使用同一套基准代码，便可为移动平台、桌面端和网页端开发应用。此外，团队也分享了来自全球互联网公司 [腾讯](https://www.youtube.com/watch?v=DVGIBU109nI&feature=youtu.be) 的成功案例，让现场观众体验了一把 Flutter 的蓬勃活力，亲眼见证越来越多的应用正在通过 Flutter 缔造精彩。
 

--- a/src/posts/launching-flutter-12-at-mobile-world.md
+++ b/src/posts/launching-flutter-12-at-mobile-world.md
@@ -1,14 +1,9 @@
 ---
-title: Launching Flutter 1.2 at Mobile World Congress
 title: 首个稳定更新版 —— Flutter 1.2 发布
 toc: true
 ---
 
-*Posted by the Flutter team*
-
 *由 Flutter 团队发布*
-
-The Flutter team is coming to you [live this week from Mobile World Congress](https://www.mwcbarcelona.com/session/flutter-google-toolkit-for-building-mobile-experiences/)in Barcelona, the largest annual gathering of the mobile technology industry. One year ago, we announced the first beta of Flutter at this same event, and since then [Flutter has grown faster than we could have imagined](http://sotagtrends.com/?tags=[ionic-framework,react-native,flutter,xamarin]&relative=false). So it seems fitting that we celebrate this anniversary occasion with our first stable update release for Flutter.
 
 2019 [世界移动通信大会](https://www.mwcbarcelona.com/session/flutter-google-toolkit-for-building-mobile-experiences/) (MWC 大会) 于 2 月 27 日在巴塞罗那顺利拉开帷幕。值此移动盛会，Flutter 团队宣布正式推出 Flutter 1.2。
 其实，这个大会对 Flutter 有着特别的纪念意义，因为 Flutter 的首个 beta 测试版正是在去年的 MWC 大会上与大家见面的，自此以后，Flutter 的发展速度远[超我们的想象](http://sotagtrends.com/?tags=[ionic-framework,react-native,flutter,xamarin]&relative=false)。
@@ -18,130 +13,70 @@ The Flutter team is coming to you [live this week from Mobile World Congress](ht
 
 ## Flutter 1.2
 
-Flutter 1.2 is the first feature update for Flutter. We've focused this release on a few major areas:
-
 作为 Flutter 1.0 之后的首次更新， Flutter 1.2 围绕以下点进行了重点优化与改进:
 
--   Improved stability, performance and quality of the core framework.
-    
-    提升核心框架的稳定性、性能和质量
-    
--   Work to polish visual finish and functionality of existing widgets.
-
-    改进现有 widget 视觉效果和功能
-
--   New web-based tooling for developers building Flutter applications.
-
-    为 Flutter 开发者提供全新的基于 Web 的调试工具
-
-Having shipped Flutter 1.0, we focused a good deal of energy in the last couple of months on improving our testing and code infrastructure, clearing a backlog of pull requests, and improving performance and quality of the overall framework. We have a comprehensive [list of these requests in the Flutter wiki](https://github.com/flutter/flutter/wiki/Release-Notes---Changes-in-1.2.0) for those who are interested in the specifics. This work also included broader support for new UI languages such as Swahili.
+-   提升核心框架的稳定性、性能和质量
+-   改进现有 widget 视觉效果和功能
+-   为 Flutter 开发者提供全新的基于 Web 的调试工具
 
 自 Flutter 1.0 发布已经过去几个月了，我们在这段时间内集中精力改进了测试和代码基础框架，解决了此前积压的 pull requests，并全面提升了框架的质量与性能。
 有兴趣的开发者们可以前往 Flutter wiki 页面，[查看完整的 pull requests 列表](https://github.com/flutter/flutter/wiki/Release-Notes---Changes-in-1.2.0)。此外，我们还在这次更新中加强了对 Swahili 等新 UI 设计语言的支持。
 
-We continue to make improvements to both the Material and Cupertino widget sets, to support more flexible usage of Material and continue to strive towards pixel-perfect fidelity on iOS. The latter work includes support for [floating cursor text editing](https://github.com/flutter/flutter/pull/25384), as well as showing continued attention to minor details (for example, we updated the way the text editing cursor paints on iOS for a faithful representation of the animation and painting order). We added support for a broader set of animation easing functions, [inspired by the work of Robert Penner](http://robertpenner.com/easing/). And we added support for new keyboard events and mouse hover support, in preparation for deeper support for desktop-class operating systems.
-
 我们将继续改进 Material 和 Cupertino 系列的 widgets，为开发者提供更加灵活的 Material 设计体验，并持续在 iOS 设备上继续交付完美的像素保真度。为此，我们添加了对[浮动光标文本编辑](https://github.com/flutter/flutter/pull/25384)的支持，
 并且对许多细节进行了进一步优化 (例如，我们更新了文本编辑光标在 iOS 设备上的绘制方式，以便真实呈现动画和绘图顺序)。
 受 [Robert Penner 作品](http://robertpenner.com/easing/)的启发，我们扩展了动画缓动函数的支持范围。此外，Flutter 1.2 还引入了全新的键盘事件和鼠标悬停支持，以作好准备为桌面级操作系统提供深层支持。
-
-The plug-in team has also been busy in Flutter 1.2, with work well underway to support [in-app purchases](https://github.com/flutter/plugins/tree/master/packages/in_app_purchase), as well as many bug fixes for [video player](https://pub.dartlang.org/packages/video_player), [webview](https://pub.dartlang.org/packages/webview_flutter), and [maps](https://pub.dartlang.org/packages/google_maps_flutter). And thanks to a [pull request contributed by a developer from Intuit](https://github.com/flutter/flutter/pull/24440), we now have support for [Android App Bundles](https://developer.android.com/guide/app-bundle/), a new packaging format that helps in reducing app size and enables new features like dynamic delivery for Android apps.
 
 与此同时，Flutter 插件团队也在积极展开针对 Flutter 1.2 发布的相关优化工作，
 主要负责实现 [应用内购买](https://github.com/flutter/plugins/tree/master/packages/in_app_purchase) 支持，以及修复[视频播放器 (video player)](https://pub.dartlang.org/packages/video_player)、[webview](https://pub.dartlang.org/packages/webview_flutter) 和 [地图 (maps)](https://pub.dartlang.org/packages/google_maps_flutter) 中的一些错误。
 另外，我们还合并了一个来自 [Intuit 工程师提交的 pull request](https://github.com/flutter/flutter/pull/24440)，在 Flutter 中添加了 [Android App Bundles](https://developer.android.com/guide/app-bundle/) 支持。
 Android App Bundles 是一种新的封装格式，它能有效减小应用的体积并启动应用动态交付等新特性。
 
-Lastly, Flutter 1.2 includes the Dart 2.2 SDK, an update that brings significant performance improvements to compiled code along with new language support for initializing sets. For more information on this work, you can [read the Dart 2.2 announcement](https://medium.com/dartlang/announcing-dart-2-2-faster-native-code-set-literal-support-7e2ab19cc86d).
-
 最后，Flutter 1.2 还包含了 Dart 2.2 SDK，此项更新为代码编译带来了显著的性能提升，
 并且为初始化集合提供了新语言支持。更多信息，请阅读[《Dart 2.2 发布说明》](https://medium.com/dartlang/announcing-dart-2-2-faster-native-code-set-literal-support-7e2ab19cc86d)。
-
-(As an aside, some might wonder why this release is numbered 1.2. Our goal is to ship a 1.x release to the 'beta' channel on about a monthly basis, and to release an update approximately every quarter to the 'stable' channel that is ready for production usage. Our 1.1 last month was a beta release, and so 1.2 is therefore our first stable release.)
 
 特别说明: 有些读者或许会好奇为什么这个版本的编号是 1.2，请允许我在这里稍作解释。
 我们的目标是大概每个月向 "测试版” 渠道发布 1.x 版本的 Flutter，
 然后每季度向 “稳定版” 渠道发布可在生产环境下使用的更新版本。
 上个月发布的 1.1 是测试版本，因此 1.2 是我们的首个稳定更新版本。
 
-## New Tools for Flutter Developers
-
 ## 新的调试工具
-
-Mobile developers come from a variety of backgrounds and often prefer different programming tools and editors. Flutter itself supports different tools, including first-class support for Android Studio and Visual Studio Code as well as support for building apps from the command line, so we knew we needed flexibility in how we expose debugging and runtime inspection tools.
 
 每位开发者都有着不同的技术背景，偏爱的编程工具和编辑器也不尽相同。
 为此，Flutter 添加了多种工具支持，其中包括 Android Studio 和 Visual Studio Code 的 一级支持，以及支持命令行构建工具，这也就意味着开发者需要更加灵活的调试和运行时检查工具。
 
-Alongside Flutter 1.2, we're delighted to preview a new [web-based suite of programming tools to help Flutter developers debug and analyze their apps](https://flutter.github.io/devtools/). These tools are now available for installation alongside the extensions and add-ins for Visual Studio Code and Android Studio, and offer a number of capabilities:
-
 所以我们在发布 Flutter 1.2 的同时，还带来了全新的[基于 Web 的调试工具套件](https://flutter.github.io/devtools/)，目的是帮助您更好地分析与调试应用性能。
 这些工具支持与 Visual Studio Code 和 Android Studio 的扩展程序及加载项一同安装，并且提供多种功能：
 
--   A widget inspector, which enables visualization and exploration of the tree hierarchy that Flutter uses for rendering.
-
-    Widget 检查器: 对 Flutter 用于渲染的树状分级结构实现可视化和直观的探索；
-
--   A timeline view that helps you diagnose your application at a frame-by-frame level, identifying rendering and computational work that may cause animation 'jank' in your apps.
-
-    时间线视图: 可帮助您逐帧诊断自己的应用，并识别可能造成应用动画 “卡顿” 的渲染和计算问题；
-
--   A full source-level debugger that lets you step through code, set breakpoints and investigate the call stack.
-
-    源代码级调试器: 支持单步执行代码，设置断点并检查调用堆栈；
-
--   A logging view that shows activity you log from your application as well as network, framework and garbage collection events.
-
-    日志记录视图: 显示应用所记录的活动以及网络、框架和垃圾回收等事件。
+-   Widget 检查器: 对 Flutter 用于渲染的树状分级结构实现可视化和直观的探索；
+-   时间线视图: 可帮助您逐帧诊断自己的应用，并识别可能造成应用动画 “卡顿” 的渲染和计算问题；
+-   源代码级调试器: 支持单步执行代码，设置断点并检查调用堆栈；
+-   日志记录视图: 显示应用所记录的活动以及网络、框架和垃圾回收等事件。
 
 ![flutter-devtools-preview](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot2-release/flutter-devtools-preview.png){:width="85%"}
 
-We plan to invest further in this new web-based tooling for both Flutter and Dart developers and, as integration for web-based experiences improves, we plan to build these services directly into tools like Visual Studio Code.
-
 为了给 Flutter 和 Dart 开发者创造更好的开发体验，我们将进一步加大对基于 web 的调试工具的投入。此外，随着 web 集成技术的不断发展，我们还计划将这些服务直接添加到 Visual Studio Code 等工具中。
-
-## What's next for Flutter?
 
 ## 下一步工作
 
-In addition to the engineering work, we took some time after Flutter 1.0 to [document our 2019 roadmap](https://github.com/flutter/flutter/wiki/Roadmap), and you'll see that we've got plenty of work ahead of us.
-
 发布 Flutter 1.0 之后，除了日常开发工作之外，我们还规划了 [Flutter 2019 产品路线图](https://github.com/flutter/flutter/wiki/Roadmap)，从中您会发现我们未来仍很多工作要做。
-
-A big focus for 2019 is growing Flutter beyond mobile platforms. At [Flutter Live, we announced a project codenamed "Hummingbird"](https://youtu.be/5SZZfpkVhwk?list=PLOU2XLYxmsILq4ysYNWXq5TOGLgYDJgVD&t=175), which brings Flutter to the web, and we plan to share a technical preview in the coming months. In addition, we continue to work on bringing Flutter to desktop-class devices; this requires work both at the framework level as described above, as well as the ability to package and deploy applications for operating systems like Windows and Mac, in which we're investing through our [Flutter Desktop Embedding project](https://github.com/google/flutter-desktop-embedding).
 
 2019 年的一个工作重点是将 Flutter 的应用范围扩展到移动平台之外。我们在 Flutter Live 上启动了 [Hummingbird 计划](https://youtu.be/5SZZfpkVhwk?list=PLOU2XLYxmsILq4ysYNWXq5TOGLgYDJgVD&t=175)，加快推进 Flutter 在 Web 端的发展。我们会接下来的几个月里公布该项目的初步技术成果，请大家拭目以待！另外，我们还计划将 Flutter 引入到桌面开发中。因此，除了上述框架层面的开发工作之外，我们还会通过 [Flutter 跨平台桌面应用计划 (Flutter Desktop Embedding Project)](https://github.com/google/flutter-desktop-embedding) 帮助各位开发者在 Windows 和 Mac 等操作系统上封装和部署应用。
 
-
-## Flutter Create: what can you do with 5K of Dart?
-
 ## Flutter Create: 您能使用 5K 的 Dart 代码做些什么？
 
-This week, we're also excited to launch [Flutter Create](http://flutter.dev/create), a contest that challenges you to build something interesting, inspiring, and beautiful with Flutter using five kilobytes or less of Dart code. 5K isn't a lot --- for a typical MP3 file, it's about a third of a second of music --- but we're betting you can amaze us with what you can achieve in Flutter with such a small amount of code.
-
-[Flutter Create 挑战赛](http://flutter.dev/create)将从本周起开始接收报名，你敢来参加吗？参赛者需要利用 Flutter 构建充满创意和趣味的精美应用，并把这一切全部浓缩到 5K 的 Dart 代码里。5K 并不多，按照普通 MP3 格式的标准来算，差不多相当于三分之一秒的音乐。但我们敢说，有了 Flutter 的帮助，即使是使用如此少量的代码，您也能制作出令人大开眼界的应用。
+[Flutter Create 挑战赛](/create)将从本周起开始接收报名，你敢来参加吗？参赛者需要利用 Flutter 构建充满创意和趣味的精美应用，并把这一切全部浓缩到 5K 的 Dart 代码里。5K 并不多，按照普通 MP3 格式的标准来算，差不多相当于三分之一秒的音乐。但我们敢说，有了 Flutter 的帮助，即使是使用如此少量的代码，您也能制作出令人大开眼界的应用。
 
 ![flutter-create-contest](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot2-release/flutter-create-contest-heroimg.png){:width="85%"}
 
-The contest runs until April 7th, so you've got a few weeks to build something cool. We have some great prizes, including a [fully-loaded iMac Pro developer workstation](https://www.apple.com/imac-pro/specs/) with a 14-core processor and 128GB of memory that is worth over $10,000! We'll be announcing the winners at [Google I/O](https://events.google.com/io/), where we'll have a number of Flutter talks, codelabs and activities.
-
 挑战赛将于 4 月 7 日结束，因此您将有几周的时间来构建出色应用。我们准备了一些很棒的奖品，其中包括一台搭载 14 核处理器和 128GB 内存的[顶配版 iMac Pro 工作站](https://www.apple.com/imac-pro/specs/)，价值超过 10,000 美元！我们将在 [Google I/O 大会](https://events.google.com/io/)上宣布获胜者名单，并且还会在此期间开展多个 Flutter 演讲、Codelab 课程和活动，敬请期待！
 
-## In closing
-
 ## 结语
-
-Flutter is now one of the top 20 software repos on Github, and the worldwide community grows with every passing month. Between meetups in [Chennai, India](https://twitter.com/Nikkitagandhi/status/1099745911985467392), articles from [Port Harcourt, Nigeria](https://twitter.com/Zfinix1/status/1079892033060392962), apps from [Copenhagen, Denmark](https://twitter.com/koorankka/status/1098579826355642368)and incubation studios in [New York City, USA](https://www.hotreload.io/), it's clear that Flutter continues to become a worldwide phenomenon, thanks to you. You can see Flutter in [apps that have hundreds of millions of users](https://play.google.com/store/apps/details?id=com.alibaba.intl.android.apps.poseidon), and in apps from [entrepreneurs who are bringing their first idea to market](https://play.google.com/store/apps/details?id=com.kissaan.gomitra). It's exciting to see the range of ideas you have, and we hope that we can help you express them with Flutter.
 
 Flutter 现已进入 Github Top 20 软件库，与此同时，Flutter 全球社区也在以惊人的速度蓬勃发展，为世界各地的开发者正带去独特的编程乐趣——[印度清奈的开发者聚会](https://twitter.com/Nikkitagandhi/status/1099745911985467392)，[尼日利亚哈科特港的报道](https://twitter.com/Zfinix1/status/1079892033060392962)，[丹麦哥本哈根的应用](https://twitter.com/koorankka/status/1098579826355642368)，以及[美国纽约的孵化工作室](https://www.hotreload.io/) —— 从中我们可以清楚地看到 Flutter 正在成为一种全球现象，而这一切都离不开您的贡献！Flutter 作为移动开发领域一股不容小觑的新生力量，不仅为开发者赢得了[亿万用户](https://play.google.com/store/apps/details?id=com.alibaba.intl.android.apps.poseidon)，还[帮助创业者把理念推向市场](https://play.google.com/store/apps/details?id=com.kissaan.gomitra)。我们非常高兴看到您拥有如此多的创意，也希望能够帮助您使用 Flutter 来呈现这些创意。
 
 ![flutter-deep-dive-srmu](https://files.flutter-io.cn/posts/flutter-cn/2019/flutter-1dot2-release/flutter-deep-dive-srmu.jpg){:width="85%"}
 
-*Attendees of a Flutter deep dive at Technozzare, SRM University.*
-
 *在印度 SRM 大学参加 Flutter 高级研讨会的与会者*
-
-Finally, we've recently launched a YouTube channel exclusively dedicated to Flutter. Be sure to subscribe at [flutter.dev/youtube](https://flutter.dev/youtube) for shows including the [Boring Flutter Development Show](https://www.youtube.com/playlist?list=PLjxrf2q8roU3ahJVrSgAnPjzkpGmL9Czl), [Widget of the Week](https://www.youtube.com/playlist?list=PLjxrf2q8roU23XGwz3Km7sQZFTdB996iG), and [Flutter in Focus](https://www.youtube.com/playlist?list=PLjxrf2q8roU2HdJQDjJzOeO6J3FoFLWr2). You'll also find a new case study from [Dream11, a popular Indian fantasy sports site](https://youtu.be/lCeRZhoqEP8), as well as other [Developer Stories](https://www.youtube.com/playlist?list=PLjxrf2q8roU33POuWi4bK0zvDpAHK6759). See you there!
 
 我们最近还在 YouTube 网站上专门为 Flutter 开设了一个新频道。欢迎前来 [flutter.dev/youtube](https://flutter.dev/youtube) 进行订阅观看！
 这个频道包含了大家非常喜爱的一些视频合集如 [Boring Flutter Development Show](https://www.youtube.com/playlist?list=PLjxrf2q8roU3ahJVrSgAnPjzkpGmL9Czl)、[Widget of the Week](https://www.youtube.com/playlist?list=PLjxrf2q8roU23XGwz3Km7sQZFTdB996iG) 和 [Flutter in Focus](https://www.youtube.com/playlist?list=PLjxrf2q8roU2HdJQDjJzOeO6J3FoFLWr2)，


### PR DESCRIPTION
双语文档显示工具忽略了 post/ 目录，因此需要将本目录下面的文章中的英文删除。

未来再同步进来的官方博客内容，也无需再加入英文。
