### PR TITLE
Redirect site shared

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "site-shared"]
 	path = site-shared
-	url = https://github.com/dart-lang/site-shared.git
-	branch = rearch
+	url = https://github.com/cfug/site-shared
+	branch = main
 [submodule "flutter"]
 	path = flutter
 	url = https://github.com/flutter/flutter


### PR DESCRIPTION
Redirect site-shared from https://github.com/dart-lang/site-shared to https://github.com/cfug/site-shared.

Wikis need further updates.