### PR TITLE
[Infra] 🔒️ Request @cfug/localization as CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @chenglu @AlexV525 @Vadaski @MeandNi @Nayuta403
+* @cfug/localization


### PR DESCRIPTION
Using the @cfug/localization group as the CODEOWNERS instead of specified users.