### PR TITLE
Fix the Cookbook URLs.

### DIFF
--- a/src/_includes/docs/cookbook-group-index.md
+++ b/src/_includes/docs/cookbook-group-index.md
@@ -5,5 +5,5 @@
       | sort: 'title' %}
 
 {% for recipe in recipes %}
-- [{{ recipe.title }}]({{ site.url }}{{ recipe.url }})
+- [{{ recipe.title }}]({{ site.main-url }}{{ recipe.url }})
 {% endfor %}


### PR DESCRIPTION
### 解决的 Issues

Fix: #1102 

### 更新内容描述

这个文件复制动态的生成 cookbook 的 URL，替换 `site.url` 为 `site.main-url` 即可。
