### PR TITLE
Revert change to redirect by fixing header

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -39,7 +39,7 @@
       { "source": "/desktop/windows", "destination": "/development/platform-integration/windows/building", "type": 301 },
       { "source": "/desktop/macos", "destination": "/development/platform-integration/macos/building", "type": 301 },
       { "source": "/desktop/linux", "destination": "/development/platform-integration/linux/building", "type": 301 },
-      { "source": "/docs/perf/rendering/*", "destination": "/docs/perf", "type": 301 },
+      { "source": "/perf/rendering/*", "destination": "/perf", "type": 301 },
       { "source": "/developing-packages", "destination": "/development/packages-and-plugins/developing-packages", "type": 301 },
       { "source": "/development/ios-14", "destination": "/development/platform-integration/ios/ios-debugging", "type": 301 },
       { "source": "/development/ios-project-migration", "destination": "/development/platform-integration/ios", "type": 301 },

--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -101,7 +101,7 @@
               <a class="dropdown-item {% if route contains '/development/tools/hot-reload' %} active{% endif %}"
                  href="/development/tools/hot-reload">热重载</a>
               <a class="dropdown-item {% if route contains '/perf/ui-performance' %} active{% endif %}"
-                 href="/docs/perf/rendering/ui-performance">性能分析</a>
+                 href="/docs/perf/ui-performance">性能分析</a>
               <a class="dropdown-item {% if route contains '/get-started/install' %} active{% endif %}"
                  href="/docs/get-started/install">安装 Flutter</a>
               <a class="dropdown-item {% if route contains '/development/tools/devtools' %} active{% endif %}"


### PR DESCRIPTION
I think the problem wasn't the redirect itself, as the other redirects don't include `/docs`, but rather the header had an outdated link without a redirect. 

Tracking a similar fix up-stream in https://github.com/flutter/website/pull/8289#discussion_r1113841877