### PR TITLE
Update page-github-links.html

### DIFF
--- a/src/_includes/page-github-links.html
+++ b/src/_includes/page-github-links.html
@@ -5,8 +5,7 @@
 
 <p id="page-github-links">
   <span>
-    <t>Unless stated otherwise, the documentation on this site reflects the latest stable version of Flutter. Page last updated on {{page.date | toSimpleDate}}.</t>
-    <t>除非另有说明，本网站文档都将基于 Flutter 的最新稳定版本。页面最近更新于 {{page.date | toSimpleDate}}。</t>
+    除非另有说明，本文档之所提及 适用于 Flutter 的最新稳定版本，本页面最后更新时间: {{page.date | toSimpleDate}}。
   </span>
   <a href="{{pageSource}}" target="_blank" rel="noopener"><t>View source</t><t>查看文档源码</t></a>
   <span> <t>or</t><t>或者</t> </span>


### PR DESCRIPTION
感觉好像 `<t>` 标签没有很好的被处理，所以就干脆只保留中文吧。