### PR TITLE
Fix: Page last updated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,6 +129,7 @@ jobs:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
         with:
           submodules: recursive
+          fetch-depth: 0
       - name: Enable Corepack
         run: corepack enable
       - uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,6 +129,7 @@ jobs:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
         with:
           submodules: recursive
+          # docs.flutter.cn | https://github.com/cfug/flutter.cn/pull/1518
           fetch-depth: 0
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
         with:
           submodules: recursive
+          # docs.flutter.cn | https://github.com/cfug/flutter.cn/pull/1518
+          fetch-depth: 0
       - name: Enable Corepack
         run: corepack enable
       - uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6

--- a/tool/translator/robots.txt
+++ b/tool/translator/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Allow: /
+
+Sitemap: https://docs.flutter.cn/sitemap.xml


### PR DESCRIPTION
目前在 `actions/checkout` (GitHub Action) 中未取出所有历史记录，
导致所有页面底部的更新时间都会被统一到最近 1 次的提交时间。

预期：所有页面对应各自的最新更新时间。
影响范围：所有页面和 [sitemap.xml](https://docs.flutter.cn/sitemap.xml)

![image](https://github.com/user-attachments/assets/fccd8881-8632-4b7a-8668-b2b6ca890ed2)

> 11ty 关于内容日期的文档 (git Last Modified)： https://www.11ty.dev/docs/dates/  