### PR TITLE
[内容修订] src/content/get-started/flutter-for/android-devs.md

### DIFF
--- a/src/content/get-started/flutter-for/android-devs.md
+++ b/src/content/get-started/flutter-for/android-devs.md
@@ -1678,7 +1678,7 @@ Next, you'll need to declare these images in your `pubspec.yaml` file:
 
 ```yaml
 assets:
- - images/my_icon.jpeg
+ - images/my_icon.png
 ```
 
 You can then access your images using `AssetImage`:
@@ -1687,7 +1687,7 @@ You can then access your images using `AssetImage`:
 
 <?code-excerpt "lib/images.dart (asset-image)"?>
 ```dart
-AssetImage('images/my_icon.jpeg')
+AssetImage('images/my_icon.png')
 ```
 
 or directly in an `Image` widget:


### PR DESCRIPTION
Fix image suffix mismatch in description

- [内容修订](?template=src/content/get-started/flutter-for/android-devs.md)
