### PR TITLE
[内容修订] src/_includes/docs/install/devices/android-emulator.md

### DIFF
--- a/src/_includes/docs/install/devices/android-emulator.md
+++ b/src/_includes/docs/install/devices/android-emulator.md
@@ -8,8 +8,7 @@
 {% when 'Windows','Linux' -%}
 {% assign images = '**x86 Images**' -%}
 {% when 'macOS' -%}
-<!-- {% assign images = '**x86 Images** if your Mac runs on an Intel CPU or **ARM Images** if your Mac runs on an Apple CPU' -%} -->
-{% assign images = '**x86 Images**（Intel CPU 的 Mac）或者 **ARM Images**（Apple CPU 的 Mac）' -%}
+{% assign images = '**x86 Images** if your Mac runs on an Intel CPU or **ARM Images** if your Mac runs on an Apple CPU' -%}
 {% endcase -%}
 
 To configure your Flutter app to run in an Android emulator,
@@ -75,7 +74,11 @@ follow these steps to create and select an emulator.
 
 1. Click {{images}}.
 
+   {% if include.devos == 'macOS' %}
+   单击 **x86 Images**（Intel CPU 的 Mac）或者 **ARM Images**（Apple CPU 的 Mac）。
+   {% else %}
    单击 {{images}}。
+   {% endif %}
 
 1. Click one system image for the Android version you want to emulate.
 


### PR DESCRIPTION
### 解决的 Issues

Fix #1570

### 更新内容描述
修复macOS安装文档中重复显示  
 “Click x86 Images …” 与 “单击 x86 Images …” 的问题  

具体做法:
  1. 将 macOS 的 images 变量改回纯英文
  2. 用 {% if include.devos == 'macOS' %} 包裹专属中文翻译
  3. 为其他平台保留通用中文行，避免 Windows/Linux 页面缺句 该改动不影响 Windows/Linux 中文安装文档
